### PR TITLE
Fix typo in docs/CONFIG_FILE.md

### DIFF
--- a/docs/CONFIG_FILE.md
+++ b/docs/CONFIG_FILE.md
@@ -46,9 +46,9 @@ Available options for `FORMATTER_NAME` are:
 - `asciidoc document`
 - `asciidoc table`
 - `json`
-- `markdonw`
-- `markdonw document`
-- `markdonw table`
+- `markdown`
+- `markdown document`
+- `markdown table`
 - `pretty`
 - `tfvars hcl`
 - `tfvars json`


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR fixes typo (`markdonw` → `markdown`) in `docs/CONFIG_FILE.md`.

### Issues Resolved

none

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
