### PR TITLE
Normalize variables with CRLF line ending in heredoc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,5 +30,8 @@ indent_size = 2
 [*.tf]
 trim_trailing_whitespace = false
 
+[**/inputs-crlf/variables.tf]
+end_of_line = crlf
+
 [Makefile]
 indent_style = tab

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -139,7 +139,8 @@ func loadInputs(tfmodule *tfconfig.Module) ([]*tfconf.Input, []*tfconf.Input, []
 	var optional = make([]*tfconf.Input, 0, len(tfmodule.Variables))
 
 	for _, input := range tfmodule.Variables {
-		inputDescription := input.Description
+		// convert CRLF to LF early on (https://github.com/terraform-docs/terraform-docs/issues/305)
+		inputDescription := strings.Replace(input.Description, "\r\n", "\n", -1)
 		if inputDescription == "" {
 			inputDescription = loadComments(input.Pos.Filename, input.Pos.Line)
 		}

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -340,6 +340,35 @@ func TestLoadInputs(t *testing.T) {
 	}
 }
 
+func TestLoadInputsLineEnding(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "load module inputs from file with lf line ending",
+			path:     "inputs-lf",
+			expected: "The quick brown fox jumps\nover the lazy dog\n",
+		},
+		{
+			name:     "load module inputs from file with crlf line ending",
+			path:     "inputs-crlf",
+			expected: "The quick brown fox jumps\nover the lazy dog\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			module, _ := loadModule(filepath.Join("testdata", tt.path))
+			inputs, _, _ := loadInputs(module)
+
+			assert.Equal(1, len(inputs))
+			assert.Equal(tt.expected, string(inputs[0].Description))
+		})
+	}
+}
+
 func TestLoadOutputs(t *testing.T) {
 	type expected struct {
 		outputs int

--- a/internal/module/testdata/inputs-crlf/variables.tf
+++ b/internal/module/testdata/inputs-crlf/variables.tf
@@ -1,0 +1,7 @@
+variable "multi-line-lf" {
+  type = string
+  description = <<-EOT
+  The quick brown fox jumps
+  over the lazy dog
+  EOT
+}

--- a/internal/module/testdata/inputs-lf/variables.tf
+++ b/internal/module/testdata/inputs-lf/variables.tf
@@ -1,0 +1,7 @@
+variable "multi-line-crlf" {
+  type = string
+  description = <<-EOT
+  The quick brown fox jumps
+  over the lazy dog
+  EOT
+}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR normalizes input variables which has CRLF as line ending in multi-line heredoc style description. It will convert them internally to LF early on and continue parsing and rendering them as usual.

### Issues Resolved

Fixes #305 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
