### PR TITLE
Allow dependabot to update github action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Since terraform-docs uses GitHub actions and dependabot is now native to GitHub, it would be nice to keep those up-to-date automatically via dependabot. Below is an example of a basic dependabot.yaml which GitHub suggests. 

https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot#example-dependabotyml-file-for-github-actions


Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

I believe this is not applicable since I'm not making changes to the actual script.

#### Documentation

I believe this is not applicable since I'm not making changes to the actual script.


#### Code Style

I believe this is not applicable since I'm not making changes to the actual script.

