### PR TITLE
Prevent segfault error if input arg is a file

### DIFF
--- a/internal/cli/reader.go
+++ b/internal/cli/reader.go
@@ -19,7 +19,7 @@ func (c *cfgreader) exist() (bool, error) {
 	if c.file == "" {
 		return false, fmt.Errorf("config file name is missing")
 	}
-	if info, err := os.Stat(c.file); os.IsNotExist(err) || info.IsDir() {
+	if info, err := os.Stat(c.file); os.IsNotExist(err) || info == nil || info.IsDir() {
 		return false, err
 	}
 	return true, nil

--- a/internal/cli/reader_test.go
+++ b/internal/cli/reader_test.go
@@ -36,6 +36,13 @@ func TestExists(t *testing.T) {
 			wantErr:  true,
 			errMsg:   "config file name is missing",
 		},
+		{
+			name:     "main argument is a file",
+			config:   cfgreader{file: "testdata/sample-config.yaml/some-config.yaml"},
+			expected: false,
+			wantErr:  true,
+			errMsg:   "stat testdata/sample-config.yaml/some-config.yaml: not a directory",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR fixes a regression added in `v0.10.0` in which if the input arg is a file instead of a directory the terraform-docs crashes with `panic: runtime error: invalid memory address or nil pointer dereference` error instead of gracefully handle it.

### Issues Resolved

Fixes #297 
Related to #325 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
