### PR TITLE
Show correct version when brew installs it

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,9 +17,12 @@ var (
 	buildDate  string
 )
 
+// Load defaults for info variables
 func init() {
-	// Load defaults for info variables
 	if version == "" {
+		version = dev
+	}
+	if version == "v0.0.0-" { // building in a directory which is not a git repository
 		version = dev
 	}
 	if commitHash == "" {


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

When `brew` attempts to install the binary downloads a tarball and extract it and runs `make build` in it, at that point that folder is not a git repository hence `git describe tag` wouldn't return back the correct version. This PR ignores the default segment (i.e. `v0.0.0-`) as it should never happen.

### Issues Resolved

Fixes #331 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
