### PR TITLE
Never escape special characters in tfvars json

### DIFF
--- a/docs/formats/tfvars-json.md
+++ b/docs/formats/tfvars-json.md
@@ -93,7 +93,7 @@ generates the following output:
       "string-1": "bar",
       "string-2": null,
       "string-3": "",
-      "string-special-chars": "\\.\u003c\u003e[]{}_-",
+      "string-special-chars": "\\.<>[]{}_-",
       "string_default_empty": "",
       "string_default_null": null,
       "string_no_default": null,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-test/deep v1.0.7
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.7.0
-	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
+	github.com/iancoleman/orderedmap v0.1.0
 	github.com/imdario/mergo v0.3.11
 	github.com/spf13/cobra v1.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
-github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/iancoleman/orderedmap v0.1.0 h1:2orAxZBJsvimgEBmMWfXaFlzSG2fbQil5qzP3F6cCkg=
+github.com/iancoleman/orderedmap v0.1.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/internal/format/testdata/tfvars/json-EscapeCharacters.golden
+++ b/internal/format/testdata/tfvars/json-EscapeCharacters.golden
@@ -6,7 +6,7 @@
   "string-3": "",
   "string-2": null,
   "string-1": "bar",
-  "string-special-chars": "\\.\u003c\u003e[]{}_-",
+  "string-special-chars": "\\.<>[]{}_-",
   "number-3": "19",
   "number-4": 15.75,
   "number-2": null,

--- a/internal/format/testdata/tfvars/json-NoInputs.golden
+++ b/internal/format/testdata/tfvars/json-NoInputs.golden
@@ -6,7 +6,7 @@
   "string-3": "",
   "string-2": null,
   "string-1": "bar",
-  "string-special-chars": "\\.\u003c\u003e[]{}_-",
+  "string-special-chars": "\\.<>[]{}_-",
   "number-3": "19",
   "number-4": 15.75,
   "number-2": null,

--- a/internal/format/testdata/tfvars/json-SortByName.golden
+++ b/internal/format/testdata/tfvars/json-SortByName.golden
@@ -49,7 +49,7 @@
   "string-1": "bar",
   "string-2": null,
   "string-3": "",
-  "string-special-chars": "\\.\u003c\u003e[]{}_-",
+  "string-special-chars": "\\.<>[]{}_-",
   "string_default_empty": "",
   "string_default_null": null,
   "string_no_default": null,

--- a/internal/format/testdata/tfvars/json-SortByRequired.golden
+++ b/internal/format/testdata/tfvars/json-SortByRequired.golden
@@ -51,7 +51,7 @@
   "object_default_empty": {},
   "string-1": "bar",
   "string-3": "",
-  "string-special-chars": "\\.\u003c\u003e[]{}_-",
+  "string-special-chars": "\\.<>[]{}_-",
   "string_default_empty": "",
   "string_default_null": null,
   "with-url": ""

--- a/internal/format/testdata/tfvars/json-SortByType.golden
+++ b/internal/format/testdata/tfvars/json-SortByType.golden
@@ -50,7 +50,7 @@
   "string-1": "bar",
   "string-2": null,
   "string-3": "",
-  "string-special-chars": "\\.\u003c\u003e[]{}_-",
+  "string-special-chars": "\\.<>[]{}_-",
   "string_default_empty": "",
   "string_default_null": null,
   "string_no_default": null,

--- a/internal/format/testdata/tfvars/json.golden
+++ b/internal/format/testdata/tfvars/json.golden
@@ -6,7 +6,7 @@
   "string-3": "",
   "string-2": null,
   "string-1": "bar",
-  "string-special-chars": "\\.\u003c\u003e[]{}_-",
+  "string-special-chars": "\\.<>[]{}_-",
   "number-3": "19",
   "number-4": 15.75,
   "number-2": null,

--- a/internal/format/tfvars_json.go
+++ b/internal/format/tfvars_json.go
@@ -22,6 +22,7 @@ func NewTfvarsJSON(settings *print.Settings) *TfvarsJSON {
 // Print prints a Terraform module as Terraform tfvars JSON document.
 func (j *TfvarsJSON) Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 	copy := orderedmap.New()
+	copy.SetEscapeHTML(false)
 	for _, i := range module.Inputs {
 		copy.Set(i.Name, i.Default)
 	}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Due to limitation of `orderedmap`, special characters in `tfvars json` always were escaped which was fixed in https://github.com/iancoleman/orderedmap/pull/15, so now we're also never escaping special characters when generating `tfvars json` output.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/terraform-docs/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
