### PR TITLE
Do not escape asterisk in markdown or asciidoc

### DIFF
--- a/internal/template/sanitizer.go
+++ b/internal/template/sanitizer.go
@@ -187,7 +187,6 @@ func escapeIllegalCharacters(s string, settings *print.Settings) string {
 						line = strings.Replace(line, "‡‡‡DONTESCAPE‡‡‡", char, -1)
 					}
 					escape("_") // Escape underscore
-					escape("*") // Escape asterisk
 					return line
 				})
 			},

--- a/internal/template/sanitizer_test.go
+++ b/internal/template/sanitizer_test.go
@@ -418,21 +418,28 @@ func TestEscapeIllegalCharacters(t *testing.T) {
 			input:       "* lorem * ipsum *dolor*consectetur* `adipi * scing *elit*sit*`",
 			escapePipe:  false,
 			escapeChars: true,
-			expected:    "* lorem \\* ipsum *dolor\\*consectetur* `adipi * scing *elit*sit*`",
+			expected:    "* lorem * ipsum *dolor*consectetur* `adipi * scing *elit*sit*`",
 		},
 		{
 			name:        "escape asterisk",
 			input:       "** lorem ** ipsum **dolor**consectetur** `adipi ** scing **elit**sit**`",
 			escapePipe:  false,
 			escapeChars: true,
-			expected:    "** lorem \\*\\* ipsum **dolor\\*\\*consectetur** `adipi ** scing **elit**sit**`",
+			expected:    "** lorem ** ipsum **dolor**consectetur** `adipi ** scing **elit**sit**`",
 		},
 		{
 			name:        "escape asterisk",
 			input:       "*** lorem *** ipsum ***dolor***consectetur*** `adipi *** scing ***elit***sit***`",
 			escapePipe:  false,
 			escapeChars: true,
-			expected:    "*** lorem \\*\\*\\* ipsum ***dolor\\*\\*\\*consectetur*** `adipi *** scing ***elit***sit***`",
+			expected:    "*** lorem *** ipsum ***dolor***consectetur*** `adipi *** scing ***elit***sit***`",
+		},
+		{
+			name:        "escape asterisk",
+			input:       "**lorem ipsum dolor consectetur adipi scing elit sit**",
+			escapePipe:  false,
+			escapeChars: true,
+			expected:    "**lorem ipsum dolor consectetur adipi scing elit sit**",
 		},
 		{
 			name:        "do not escape asterisk",
@@ -454,6 +461,13 @@ func TestEscapeIllegalCharacters(t *testing.T) {
 			escapePipe:  false,
 			escapeChars: false,
 			expected:    "*** lorem *** ipsum ***dolor***consectetur*** `adipi *** scing ***elit***sit***`",
+		},
+		{
+			name:        "do not escape asterisk",
+			input:       "**lorem ipsum dolor consectetur adipi scing elit sit**",
+			escapePipe:  false,
+			escapeChars: false,
+			expected:    "**lorem ipsum dolor consectetur adipi scing elit sit**",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Originally '*' was included in illegal characters to be escaped,
specifically when formatter is markdown or asciidoc. But there's no
real point of escaping asterisk, as markdown engines will process them
properly.

Signed-off-by: Khosrow Moossavi <khos2ow@gmail.com>

Fixes #351 

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Add corresponding test cases and make sure `make test` passes.

[contribution process]: https://git.io/JtEzg
