### PR TITLE
fixed modules section visibility set via commandline (#387)

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -266,6 +266,7 @@ func (c *Config) process() {
 	}
 	c.Sections.header = c.Sections.visibility("header")
 	c.Sections.inputs = c.Sections.visibility("inputs")
+	c.Sections.modulecalls = c.Sections.visibility("modules")
 	c.Sections.outputs = c.Sections.visibility("outputs")
 	c.Sections.providers = c.Sections.visibility("providers")
 	c.Sections.requirements = c.Sections.visibility("requirements")
@@ -337,6 +338,7 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	// sections
 	settings.ShowHeader = c.Sections.header
 	settings.ShowInputs = c.Sections.inputs
+	settings.ShowModuleCalls = c.Sections.modulecalls
 	settings.ShowOutputs = c.Sections.outputs
 	settings.ShowProviders = c.Sections.providers
 	settings.ShowRequirements = c.Sections.requirements


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #387 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

terraform-docs --show-all=false --show inputs md .  -> shows only `Inputs` section
terraform-docs --hide=modules md . -> shows all sections but `modules`


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
