### PR TITLE
include Resource.Mode when sorting to ensure deterministic resource table rendering

### DIFF
--- a/internal/terraform/resource.go
+++ b/internal/terraform/resource.go
@@ -70,5 +70,5 @@ type resourcesSortedByType []*Resource
 func (a resourcesSortedByType) Len() int      { return len(a) }
 func (a resourcesSortedByType) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a resourcesSortedByType) Less(i, j int) bool {
-	return a[i].FullType() < a[j].FullType() || (a[i].FullType() == a[j].FullType())
+	return a[i].FullType()+a[i].Mode < a[j].FullType()+a[j].Mode || (a[i].FullType()+a[i].Mode == a[j].FullType()+a[j].Mode)
 }

--- a/internal/terraform/resource_test.go
+++ b/internal/terraform/resource_test.go
@@ -76,11 +76,34 @@ func TestResourcesSortedByType(t *testing.T) {
 
 	sort.Sort(resourcesSortedByType(resources))
 
-	expected := []string{"a_a", "a_f", "b_b", "b_d", "c_c", "c_e"}
+	expected := []string{"a_a", "a_f", "b_b", "b_d", "c_c", "c_e", "z_z", "z_z", "z_z"}
 	actual := make([]string, len(resources))
 
 	for k, i := range resources {
 		actual[k] = i.FullType()
+	}
+
+	assert.Equal(expected, actual)
+}
+
+func TestResourcesSortedByTypeAndMode(t *testing.T) {
+	assert := assert.New(t)
+	resources := sampleResources()
+
+	sort.Sort(resourcesSortedByType(resources))
+
+	expected := []string{"a_a_m", "a_f_m", "b_b_m", "b_d_m", "c_c_m", "c_e_m", "z_z", "z_z_d", "z_z_m"}
+	actual := make([]string, len(resources))
+
+	for k, i := range resources {
+		v := i.FullType()
+		switch i.Mode {
+		case "managed":
+			v = v + "_m"
+		case "data":
+			v = v + "_d"
+		}
+		actual[k] = v
 	}
 
 	assert.Equal(expected, actual)
@@ -129,6 +152,27 @@ func sampleResources() []*Resource {
 			ProviderSource: "hashicorp/f",
 			Mode:           "managed",
 			Version:        "1.6.0",
+		},
+		{
+			ProviderName:   "z",
+			Type:           "z",
+			ProviderSource: "hashicorp/a",
+			Mode:           "managed",
+			Version:        "1.5.0",
+		},
+		{
+			ProviderName:   "z",
+			Type:           "z",
+			ProviderSource: "hashicorp/a",
+			Mode:           "data",
+			Version:        "1.5.0",
+		},
+		{
+			ProviderName:   "z",
+			Type:           "z",
+			ProviderSource: "hashicorp/a",
+			Mode:           "",
+			Version:        "1.5.0",
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Benjamin Ash <bash@intelerad.com>

<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
With terraform-docs version v0.11.0 linux/amd64 BuildDate: 2021-02-14T17:33:17-05:00, the resource table is not rendered in a deterministic way when we have duplicate data and managed resources. This results in the following:

```
➜  falcon $ git diff README.md

platform-cluster/terraform/cluster on  feature/CPT-479-clouddr-eval-create-a-dedicated-utility-cluster-for-production! 17:32:23
➜  falcon $ ~/go/bin/terraform-docs md . > README.md && git diff README.md

platform-cluster/terraform/cluster on  feature/CPT-479-clouddr-eval-create-a-dedicated-utility-cluster-for-production! 17:32:35
➜  falcon $ ~/go/bin/terraform-docs md . > README.md && git diff README.md

platform-cluster/terraform/cluster on  feature/CPT-479-clouddr-eval-create-a-dedicated-utility-cluster-for-production! 17:32:37
➜  falcon $ ~/go/bin/terraform-docs md . > README.md && git diff README.md
diff --git a/terraform/cluster/README.md b/terraform/cluster/README.md
index 8c064f0..7ab62b7 100644
--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -42,8 +42,8 @@
 | [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/resources/lb_target_group) |
 | [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/resources/route53_record) |
 | [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/data-sources/route53_zone) |
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/resources/s3_bucket) |
 | [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/data-sources/s3_bucket) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/resources/s3_bucket) |
 | [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/resources/security_group) |
 | [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/resources/security_group_rule) |
 | [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/3.26.0/docs/resources/ssm_parameter) |

platform-cluster/terraform/cluster on  feature/CPT-479-clouddr-eval-create-a-dedicated-utility-cluster-for-production! 17:32:40

```


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Fixes #393

This PR includes the `Resource.Mode` for sorting purposes.

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Yes, I extended the unit tests to cover the issue being addressed by this PR. With my fix I could no longer reproduce the original issue described above.

[contribution process]: https://git.io/JtEzg
