### PR TITLE
Remove unused build tools from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 
 FROM golang:1.15.6-alpine AS builder
 
-RUN apk add --update --no-cache ca-certificates bash make gcc musl-dev git openssh wget curl
+RUN apk add --update --no-cache make
 
 WORKDIR /go/src/terraform-docs
 


### PR DESCRIPTION
Signed-off-by: Pujan Shah <pujan14@gmail.com>

### Description of your changes

Remove unused build tools from build container in dockerfile.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested
By running make test and by testing newly build docker image updated dockerfile.