### PR TITLE
Completely remove deprecated '--no-XXX' flags

### DIFF
--- a/cmd/asciidoc/asciidoc.go
+++ b/cmd/asciidoc/asciidoc.go
@@ -35,12 +35,6 @@ func NewCommand(config *cli.Config) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")
 	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of AsciiDoc sections [1, 2, 3, 4, 5]")
 
-	// deprecation
-	cmd.PersistentFlags().BoolVar(&config.Settings.Deprecated.NoRequired, "no-required", false, "do not show \"Required\" column or section")
-	cmd.PersistentFlags().BoolVar(&config.Settings.Deprecated.NoSensitive, "no-sensitive", false, "do not show \"Sensitive\" column or section")
-	cmd.PersistentFlags().MarkDeprecated("no-required", "use '--required=false' instead")   //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-sensitive", "use '--sensitive=false' instead") //nolint:errcheck
-
 	// subcommands
 	cmd.AddCommand(document.NewCommand(config))
 	cmd.AddCommand(table.NewCommand(config))

--- a/cmd/json/json.go
+++ b/cmd/json/json.go
@@ -30,9 +30,5 @@ func NewCommand(config *cli.Config) *cobra.Command {
 	// flags
 	cmd.PersistentFlags().BoolVar(&config.Settings.Escape, "escape", true, "escape special characters")
 
-	// deprecation
-	cmd.PersistentFlags().BoolVar(&config.Settings.Deprecated.NoEscape, "no-escape", false, "do not escape special characters")
-	cmd.PersistentFlags().MarkDeprecated("no-escape", "use '--escape=false' instead") //nolint:errcheck
-
 	return cmd
 }

--- a/cmd/markdown/markdown.go
+++ b/cmd/markdown/markdown.go
@@ -36,14 +36,6 @@ func NewCommand(config *cli.Config) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.Settings.Escape, "escape", true, "escape special characters")
 	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of Markdown sections [1, 2, 3, 4, 5]")
 
-	// deprecation
-	cmd.PersistentFlags().BoolVar(&config.Settings.Deprecated.NoRequired, "no-required", false, "do not show \"Required\" column or section")
-	cmd.PersistentFlags().BoolVar(&config.Settings.Deprecated.NoSensitive, "no-sensitive", false, "do not show \"Sensitive\" column or section")
-	cmd.PersistentFlags().BoolVar(&config.Settings.Deprecated.NoEscape, "no-escape", false, "do not escape special characters")
-	cmd.PersistentFlags().MarkDeprecated("no-required", "use '--required=false' instead")   //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-sensitive", "use '--sensitive=false' instead") //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-escape", "use '--escape=false' instead")       //nolint:errcheck
-
 	// subcommands
 	cmd.AddCommand(document.NewCommand(config))
 	cmd.AddCommand(table.NewCommand(config))

--- a/cmd/pretty/pretty.go
+++ b/cmd/pretty/pretty.go
@@ -30,9 +30,5 @@ func NewCommand(config *cli.Config) *cobra.Command {
 	// flags
 	cmd.PersistentFlags().BoolVar(&config.Settings.Color, "color", true, "colorize printed result")
 
-	// deprecation
-	cmd.PersistentFlags().BoolVar(&config.Settings.Deprecated.NoColor, "no-color", false, "do not colorize printed result")
-	cmd.PersistentFlags().MarkDeprecated("no-color", "use '--color=false' instead") //nolint:errcheck
-
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,21 +71,6 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.OutputValues.Enabled, "output-values", false, "inject output values into outputs (default false)")
 	cmd.PersistentFlags().StringVar(&config.OutputValues.From, "output-values-from", "", "inject output values from file into outputs (default \"\")")
 
-	// deprecation
-	cmd.PersistentFlags().BoolVar(&config.Sections.Deprecated.NoHeader, "no-header", false, "do not show module header")
-	cmd.PersistentFlags().BoolVar(&config.Sections.Deprecated.NoInputs, "no-inputs", false, "do not show inputs")
-	cmd.PersistentFlags().BoolVar(&config.Sections.Deprecated.NoOutputs, "no-outputs", false, "do not show outputs")
-	cmd.PersistentFlags().BoolVar(&config.Sections.Deprecated.NoProviders, "no-providers", false, "do not show providers")
-	cmd.PersistentFlags().BoolVar(&config.Sections.Deprecated.NoRequirements, "no-requirements", false, "do not show module requirements")
-	cmd.PersistentFlags().BoolVar(&config.Sort.Deprecated.NoSort, "no-sort", false, "do no sort items")
-
-	cmd.PersistentFlags().MarkDeprecated("no-header", "use '--hide header' instead")             //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-inputs", "use '--hide inputs' instead")             //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-outputs", "use '--hide outputs' instead")           //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-providers", "use '--hide providers' instead")       //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-requirements", "use '--hide requirements' instead") //nolint:errcheck
-	cmd.PersistentFlags().MarkDeprecated("no-sort", "use '--sort=false' instead")                //nolint:errcheck
-
 	// formatter subcommands
 	cmd.AddCommand(asciidoc.NewCommand(config))
 	cmd.AddCommand(json.NewCommand(config))

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -17,19 +17,11 @@ import (
 	"github.com/terraform-docs/terraform-docs/internal/terraform"
 )
 
-type _sections struct {
-	NoHeader       bool
-	NoInputs       bool
-	NoOutputs      bool
-	NoProviders    bool
-	NoRequirements bool
-}
 type sections struct {
-	Show       []string  `yaml:"show"`
-	Hide       []string  `yaml:"hide"`
-	ShowAll    bool      `yaml:"show-all"`
-	HideAll    bool      `yaml:"hide-all"`
-	Deprecated _sections `yaml:"-"`
+	Show    []string `yaml:"show"`
+	Hide    []string `yaml:"hide"`
+	ShowAll bool     `yaml:"show-all"`
+	HideAll bool     `yaml:"hide-all"`
 
 	header       bool `yaml:"-"`
 	inputs       bool `yaml:"-"`
@@ -46,13 +38,6 @@ func defaultSections() sections {
 		Hide:    []string{},
 		ShowAll: true,
 		HideAll: false,
-		Deprecated: _sections{
-			NoHeader:       false,
-			NoInputs:       false,
-			NoOutputs:      false,
-			NoProviders:    false,
-			NoRequirements: false,
-		},
 
 		header:       false,
 		inputs:       false,
@@ -88,11 +73,6 @@ func (s *sections) validate() error {
 	}
 	if s.HideAll && len(s.Hide) != 0 {
 		return fmt.Errorf("'--hide-all' and '--hide' can't be used together")
-	}
-	for _, section := range items {
-		if changedfs["no-"+section] && contains(s.Hide, section) {
-			return fmt.Errorf("'--no-%s' and '--hide %s' can't be used together", section, section)
-		}
 	}
 	return nil
 }
@@ -145,14 +125,10 @@ type sortby struct {
 	Required bool `name:"required"`
 	Type     bool `name:"type"`
 }
-type _sort struct {
-	NoSort bool
-}
 type sort struct {
-	Enabled    bool     `yaml:"enabled"`
-	ByList     []string `yaml:"by"`
-	By         sortby   `yaml:"-"`
-	Deprecated _sort    `yaml:"-"`
+	Enabled bool     `yaml:"enabled"`
+	ByList  []string `yaml:"by"`
+	By      sortby   `yaml:"-"`
 }
 
 func defaultSort() sort {
@@ -163,19 +139,10 @@ func defaultSort() sort {
 			Required: false,
 			Type:     false,
 		},
-		Deprecated: _sort{
-			NoSort: false,
-		},
 	}
 }
 
 func (s *sort) validate() error {
-	items := []string{"sort"}
-	for _, item := range items {
-		if changedfs[item] && changedfs["no-"+item] {
-			return fmt.Errorf("'--%s' and '--no-%s' can't be used together", item, item)
-		}
-	}
 	types := []string{"required", "type"}
 	for _, item := range s.ByList {
 		switch item {
@@ -190,19 +157,12 @@ func (s *sort) validate() error {
 	return nil
 }
 
-type _settings struct {
-	NoColor     bool
-	NoEscape    bool
-	NoRequired  bool
-	NoSensitive bool
-}
 type settings struct {
-	Color      bool      `yaml:"color"`
-	Escape     bool      `yaml:"escape"`
-	Indent     int       `yaml:"indent"`
-	Required   bool      `yaml:"required"`
-	Sensitive  bool      `yaml:"sensitive"`
-	Deprecated _settings `yaml:"-"`
+	Color     bool `yaml:"color"`
+	Escape    bool `yaml:"escape"`
+	Indent    int  `yaml:"indent"`
+	Required  bool `yaml:"required"`
+	Sensitive bool `yaml:"sensitive"`
 }
 
 func defaultSettings() settings {
@@ -212,22 +172,10 @@ func defaultSettings() settings {
 		Indent:    2,
 		Required:  true,
 		Sensitive: true,
-		Deprecated: _settings{
-			NoColor:     false,
-			NoEscape:    false,
-			NoRequired:  false,
-			NoSensitive: false,
-		},
 	}
 }
 
 func (s *settings) validate() error {
-	items := []string{"escape", "color", "required", "sensitive"}
-	for _, item := range items {
-		if changedfs[item] && changedfs["no-"+item] {
-			return fmt.Errorf("'--%s' and '--no-%s' can't be used together", item, item)
-		}
-	}
 	return nil
 }
 
@@ -271,25 +219,6 @@ func (c *Config) process() {
 	c.Sections.providers = c.Sections.visibility("providers")
 	c.Sections.requirements = c.Sections.visibility("requirements")
 	c.Sections.resources = c.Sections.visibility("resources")
-
-	// sort
-	if !changedfs["sort"] && changedfs["no-sort"] {
-		c.Sort.Enabled = !c.Sort.Deprecated.NoSort
-	}
-
-	// settings
-	if !changedfs["escape"] && changedfs["no-escape"] {
-		c.Settings.Escape = !c.Settings.Deprecated.NoEscape
-	}
-	if !changedfs["color"] && changedfs["no-color"] {
-		c.Settings.Color = !c.Settings.Deprecated.NoColor
-	}
-	if !changedfs["required"] && changedfs["no-required"] {
-		c.Settings.Required = !c.Settings.Deprecated.NoRequired
-	}
-	if !changedfs["sensitive"] && changedfs["no-sensitive"] {
-		c.Settings.Sensitive = !c.Settings.Deprecated.NoSensitive
-	}
 }
 
 // validate config and check for any misuse or misconfiguration


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

In v0.10.0 flags '--no-XXX' have been deprecated in favor of their
counterparts in the format of '--X=false' (e.g. --no-header and
--header=false). And they are completely being removed now (two releases
after original announcement)

Signed-off-by: Khosrow Moossavi <khos2ow@gmail.com>

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

TBA.

[contribution process]: https://git.io/JtEzg
