### PR TITLE
Use embedded template files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ insert_final_newline = true
 indent_style = tab
 indent_size = 4
 
-[*.golden]
+[*.{golden,tmpl}]
 trim_trailing_whitespace = false
 insert_final_newline = false
 

--- a/internal/format/templates/asciidoc_document.tmpl
+++ b/internal/format/templates/asciidoc_document.tmpl
@@ -1,0 +1,149 @@
+{{- if .Settings.ShowHeader -}}
+    {{- with .Module.Header -}}
+        {{ sanitizeHeader . }}
+        {{ printf "\n" }}
+    {{- end -}}
+{{ end -}}
+
+{{- if .Settings.ShowRequirements -}}
+    {{ indent 0 "=" }} Requirements
+    {{ if not .Module.Requirements }}
+        No requirements.
+    {{ else }}
+        The following requirements are needed by this module:
+        {{- range .Module.Requirements }}
+            {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+            - {{ name .Name }}{{ $version }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowProviders -}}
+    {{ indent 0 "=" }} Providers
+    {{ if not .Module.Providers }}
+        No providers.
+    {{ else }}
+        The following providers are used by this module:
+        {{- range .Module.Providers }}
+            {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+            - {{ name .FullName }}{{ $version }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowModuleCalls -}}
+    {{ indent 0 "=" }} Modules
+    {{ if not .Module.ModuleCalls }}
+        No modules.
+    {{ else }}
+        The following Modules are called:
+        {{- range .Module.ModuleCalls }}
+
+            {{ indent 1 "=" }} {{ name .Name }}
+
+            Source: {{ .Source }}
+
+            Version: {{ .Version }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowResources -}}
+    {{ indent 0 "=" }} Resources
+    {{ if not .Module.Resources }}
+        No resources.
+    {{ else }}
+        The following resources are used by this module:
+        {{ range .Module.Resources }}
+            {{ if eq (len .URL) 0 }}
+            - {{ .FullType }}
+            {{- else -}}
+            - {{ .URL }}[{{ .FullType }}]
+            {{- end }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowInputs -}}
+    {{- if .Settings.ShowRequired -}}
+        {{ indent 0 "=" }} Required Inputs
+        {{ if not .Module.RequiredInputs }}
+            No required inputs.
+        {{ else }}
+            The following input variables are required:
+            {{- range .Module.RequiredInputs }}
+                {{ printf "\n" }}
+                {{ indent 1 "=" }} {{ name .Name }}
+
+                Description: {{ tostring .Description | sanitizeDoc }}
+
+                Type: {{ tostring .Type | type }}
+
+                {{ if or .HasDefault (not isRequired) }}
+                    Default: {{ default "n/a" .GetValue | value }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+        {{ indent 0 "=" }} Optional Inputs
+        {{ if not .Module.OptionalInputs }}
+            No optional inputs.
+        {{ else }}
+            The following input variables are optional (have default values):
+            {{- range .Module.OptionalInputs }}
+                {{ printf "\n" }}
+                {{ indent 1 "=" }} {{ name .Name }}
+
+                Description: {{ tostring .Description | sanitizeDoc }}
+
+                Type: {{ tostring .Type | type }}
+
+                {{ if or .HasDefault (not isRequired) }}
+                    Default: {{ default "n/a" .GetValue | value }}
+                {{- end }}
+            {{- end }}
+        {{ end }}
+    {{ else -}}
+        {{ indent 0 "=" }} Inputs
+        {{ if not .Module.Inputs }}
+            No inputs.
+        {{ else }}
+            The following input variables are supported:
+            {{- range .Module.Inputs }}
+                {{ printf "\n" }}
+                {{ indent 1 "=" }} {{ name .Name }}
+
+                Description: {{ tostring .Description | sanitizeDoc }}
+
+                Type: {{ tostring .Type | type }}
+
+                {{ if or .HasDefault (not isRequired) }}
+                    Default: {{ default "n/a" .GetValue | value }}
+                {{- end }}
+            {{- end }}
+        {{ end }}
+    {{- end }}
+{{ end -}}
+
+{{- if .Settings.ShowOutputs -}}
+    {{ indent 0 "=" }} Outputs
+    {{ if not .Module.Outputs }}
+        No outputs.
+    {{ else }}
+        The following outputs are exported:
+        {{- range .Module.Outputs }}
+
+            {{ indent 1 "=" }} {{ name .Name }}
+
+            Description: {{ tostring .Description | sanitizeDoc }}
+
+            {{ if $.Settings.OutputValues }}
+                {{- $sensitive := ternary .Sensitive "<sensitive>" .GetValue -}}
+                Value: {{ value $sensitive | sanitizeDoc }}
+
+                {{ if $.Settings.ShowSensitivity -}}
+                    Sensitive: {{ ternary (.Sensitive) "yes" "no" }}
+                {{- end }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end -}}

--- a/internal/format/templates/asciidoc_table.tmpl
+++ b/internal/format/templates/asciidoc_table.tmpl
@@ -1,0 +1,111 @@
+{{- if .Settings.ShowHeader -}}
+    {{- with .Module.Header -}}
+        {{ sanitizeHeader . }}
+        {{ printf "\n" }}
+    {{- end -}}
+{{ end -}}
+
+{{- if .Settings.ShowRequirements -}}
+    {{ indent 0 "=" }} Requirements
+    {{ if not .Module.Requirements }}
+        No requirements.
+    {{ else }}
+        [cols="a,a",options="header,autowidth"]
+        |===
+        |Name |Version
+        {{- range .Module.Requirements }}
+            |{{ .Name }} |{{ tostring .Version | default "n/a" }}
+        {{- end }}
+        |===
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowProviders -}}
+    {{ indent 0 "=" }} Providers
+    {{ if not .Module.Providers }}
+        No providers.
+    {{ else }}
+        [cols="a,a",options="header,autowidth"]
+        |===
+        |Name |Version
+        {{- range .Module.Providers }}
+            |{{ .FullName }} |{{ tostring .Version | default "n/a" }}
+        {{- end }}
+        |===
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowModuleCalls -}}
+    {{ indent 0 "=" }} Modules
+    {{ if not .Module.ModuleCalls }}
+        No modules.
+    {{ else }}
+        [cols="a,a,a",options="header,autowidth"]
+        |===
+        |Name|Source|Version|
+        {{- range .Module.ModuleCalls }}
+            |{{ .Name }}|{{ .Source }}|{{ .Version }}
+        {{- end }}
+        |===
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowResources -}}
+    {{ indent 0 "=" }} Resources
+    {{ if not .Module.Resources }}
+        No resources.
+    {{ else }}
+        [cols="a",options="header,autowidth"]
+        |===
+        |Name
+        {{- range .Module.Resources }}
+            {{ if eq (len .URL) 0 }}
+            |{{ .FullType }}
+            {{- else -}}
+            |{{ .URL }}[{{ .FullType }}]
+            {{- end }}
+        {{- end }}
+        |===
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowInputs -}}
+    {{ indent 0 "=" }} Inputs
+    {{ if not .Module.Inputs }}
+        No inputs.
+    {{ else }}
+        [cols="a,a,a,a{{ if .Settings.ShowRequired }},a{{ end }}",options="header,autowidth"]
+        |===
+        |Name |Description |Type |Default{{ if .Settings.ShowRequired }} |Required{{ end }}
+        {{- range .Module.Inputs }}
+            |{{ .Name }}
+            |{{ tostring .Description | sanitizeAsciidocTbl }}
+            |{{ tostring .Type | type | sanitizeAsciidocTbl }}
+            |{{ value .GetValue | sanitizeAsciidocTbl }}
+            {{ if $.Settings.ShowRequired }}|{{ ternary .Required "yes" "no" }}{{ end }}
+        {{ end }}
+        |===
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowOutputs -}}
+    {{ indent 0 "=" }} Outputs
+    {{ if not .Module.Outputs }}
+        No outputs.
+    {{ else }}
+        [cols="a,a{{ if .Settings.OutputValues }},a{{ if $.Settings.ShowSensitivity }},a{{ end }}{{ end }}",options="header,autowidth"]
+        |===
+        |Name |Description{{ if .Settings.OutputValues }} |Value{{ if $.Settings.ShowSensitivity }} |Sensitive{{ end }}{{ end }}
+        {{- range .Module.Outputs }}
+            |{{ .Name }} |{{ tostring .Description | sanitizeAsciidocTbl }}
+            {{- if $.Settings.OutputValues -}}
+                {{- $sensitive := ternary .Sensitive "<sensitive>" .GetValue -}}
+                {{ printf " " }}|{{ value $sensitive }}
+                {{- if $.Settings.ShowSensitivity -}}
+                    {{ printf " " }}|{{ ternary .Sensitive "yes" "no" }}
+                {{- end -}}
+            {{- end -}}
+        {{- end }}
+        |===
+    {{ end }}
+{{ end -}}

--- a/internal/format/templates/markdown_document.tmpl
+++ b/internal/format/templates/markdown_document.tmpl
@@ -1,0 +1,150 @@
+{{- if .Settings.ShowHeader -}}
+    {{- with .Module.Header -}}
+        {{ sanitizeHeader . }}
+        {{ printf "\n" }}
+    {{- end -}}
+{{ end -}}
+
+{{- if .Settings.ShowRequirements -}}
+    {{ indent 0 "#" }} Requirements
+    {{ if not .Module.Requirements }}
+        No requirements.
+    {{ else }}
+        The following requirements are needed by this module:
+        {{- range .Module.Requirements }}
+            {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+            - {{ name .Name }}{{ $version }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowProviders -}}
+    {{ indent 0 "#" }} Providers
+    {{ if not .Module.Providers }}
+        No providers.
+    {{ else }}
+        The following providers are used by this module:
+        {{- range .Module.Providers }}
+            {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+            - {{ name .FullName }}{{ $version }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowModuleCalls -}}
+    {{ indent 0 "#" }} Modules
+    {{ if not .Module.ModuleCalls }}
+        No modules.
+    {{ else }}
+        The following Modules are called:
+        {{- range .Module.ModuleCalls }}
+
+            {{ indent 1 "#" }} {{ name .Name }}
+
+            Source: {{ .Source }}
+
+            Version: {{ .Version }}
+
+        {{ end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowResources -}}
+    {{ indent 0 "#" }} Resources
+    {{ if not .Module.Resources }}
+        No resources.
+    {{ else }}
+        The following resources are used by this module:
+        {{ range .Module.Resources }}
+            {{ if eq (len .URL) 0 }}
+            - {{ .FullType }}
+            {{- else -}}
+            - [{{ .FullType }}]({{ .URL }})
+            {{- end }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowInputs -}}
+    {{- if .Settings.ShowRequired -}}
+        {{ indent 0 "#" }} Required Inputs
+        {{ if not .Module.RequiredInputs }}
+            No required inputs.
+        {{ else }}
+            The following input variables are required:
+            {{- range .Module.RequiredInputs }}
+                {{ printf "\n" }}
+                {{ indent 1 "#" }} {{ name .Name }}
+
+                Description: {{ tostring .Description | sanitizeDoc }}
+
+                Type: {{ tostring .Type | type }}
+
+                {{ if or .HasDefault (not isRequired) }}
+                    Default: {{ default "n/a" .GetValue | value }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+        {{ indent 0 "#" }} Optional Inputs
+        {{ if not .Module.OptionalInputs }}
+            No optional inputs.
+        {{ else }}
+            The following input variables are optional (have default values):
+            {{- range .Module.OptionalInputs }}
+                {{ printf "\n" }}
+                {{ indent 1 "#" }} {{ name .Name }}
+
+                Description: {{ tostring .Description | sanitizeDoc }}
+
+                Type: {{ tostring .Type | type }}
+
+                {{ if or .HasDefault (not isRequired) }}
+                    Default: {{ default "n/a" .GetValue | value }}
+                {{- end }}
+            {{- end }}
+        {{ end }}
+    {{ else -}}
+        {{ indent 0 "#" }} Inputs
+        {{ if not .Module.Inputs }}
+            No inputs.
+        {{ else }}
+            The following input variables are supported:
+            {{- range .Module.Inputs }}
+                {{ printf "\n" }}
+                {{ indent 1 "#" }} {{ name .Name }}
+
+                Description: {{ tostring .Description | sanitizeDoc }}
+
+                Type: {{ tostring .Type | type }}
+
+                {{ if or .HasDefault (not isRequired) }}
+                    Default: {{ default "n/a" .GetValue | value }}
+                {{- end }}
+            {{- end }}
+        {{ end }}
+    {{- end }}
+{{ end -}}
+
+{{- if .Settings.ShowOutputs -}}
+    {{ indent 0 "#" }} Outputs
+    {{ if not .Module.Outputs }}
+        No outputs.
+    {{ else }}
+        The following outputs are exported:
+        {{- range .Module.Outputs }}
+
+            {{ indent 1 "#" }} {{ name .Name }}
+
+            Description: {{ tostring .Description | sanitizeDoc }}
+
+            {{ if $.Settings.OutputValues }}
+                {{- $sensitive := ternary .Sensitive "<sensitive>" .GetValue -}}
+                Value: {{ value $sensitive | sanitizeDoc }}
+
+                {{ if $.Settings.ShowSensitivity -}}
+                    Sensitive: {{ ternary (.Sensitive) "yes" "no" }}
+                {{- end }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end -}}

--- a/internal/format/templates/markdown_table.tmpl
+++ b/internal/format/templates/markdown_table.tmpl
@@ -1,0 +1,98 @@
+{{- if .Settings.ShowHeader -}}
+    {{- with .Module.Header -}}
+        {{ sanitizeHeader . }}
+        {{ printf "\n" }}
+    {{- end -}}
+{{ end -}}
+
+{{- if .Settings.ShowRequirements -}}
+    {{ indent 0 "#" }} Requirements
+    {{ if not .Module.Requirements }}
+        No requirements.
+    {{ else }}
+        | Name | Version |
+        |------|---------|
+        {{- range .Module.Requirements }}
+            | {{ name .Name }} | {{ tostring .Version | default "n/a" }} |
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowProviders -}}
+    {{ indent 0 "#" }} Providers
+    {{ if not .Module.Providers }}
+        No providers.
+    {{ else }}
+        | Name | Version |
+        |------|---------|
+        {{- range .Module.Providers }}
+            | {{ name .FullName }} | {{ tostring .Version | default "n/a" }} |
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowModuleCalls -}}
+    {{ indent 0 "#" }} Modules
+    {{ if not .Module.ModuleCalls }}
+        No modules.
+    {{ else }}
+        | Name | Source | Version |
+        |------|--------|---------|
+        {{- range .Module.ModuleCalls }}
+            | {{ .Name }} | {{ .Source }} | {{ .Version }} |
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowResources -}}
+    {{ indent 0 "#" }} Resources
+    {{ if not .Module.Resources }}
+        No resources.
+    {{ else }}
+        | Name |
+        |------|
+        {{- range .Module.Resources }}
+        {{ if eq (len .URL) 0 }}
+            | {{ .FullType }}
+        {{- else -}}
+            | [{{ .FullType }}]({{ .URL }}) |
+        {{- end }}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowInputs -}}
+    {{ indent 0 "#" }} Inputs
+    {{ if not .Module.Inputs }}
+        No inputs.
+    {{ else }}
+        | Name | Description | Type | Default |{{ if .Settings.ShowRequired }} Required |{{ end }}
+        |------|-------------|------|---------|{{ if .Settings.ShowRequired }}:--------:|{{ end }}
+        {{- range .Module.Inputs }}
+            | {{ name .Name }} | {{ tostring .Description | sanitizeTbl }} | {{ tostring .Type | type | sanitizeTbl }} | {{ value .GetValue | sanitizeTbl }} |
+            {{- if $.Settings.ShowRequired -}}
+                {{ printf " " }}{{ ternary .Required "yes" "no" }} |
+            {{- end -}}
+        {{- end }}
+    {{ end }}
+{{ end -}}
+
+{{- if .Settings.ShowOutputs -}}
+    {{ indent 0 "#" }} Outputs
+    {{ if not .Module.Outputs }}
+        No outputs.
+    {{ else }}
+        | Name | Description |{{ if .Settings.OutputValues }} Value |{{ if $.Settings.ShowSensitivity }} Sensitive |{{ end }}{{ end }}
+        |------|-------------|{{ if .Settings.OutputValues }}-------|{{ if $.Settings.ShowSensitivity }}:---------:|{{ end }}{{ end }}
+        {{- range .Module.Outputs }}
+            | {{ name .Name }} | {{ tostring .Description | sanitizeTbl }} |
+            {{- if $.Settings.OutputValues -}}
+                {{- $sensitive := ternary .Sensitive "<sensitive>" .GetValue -}}
+                {{ printf " " }}{{ value $sensitive | sanitizeTbl }} |
+                {{- if $.Settings.ShowSensitivity -}}
+                    {{ printf " " }}{{ ternary .Sensitive "yes" "no" }} |
+                {{- end -}}
+            {{- end -}}
+        {{- end }}
+    {{ end }}
+{{ end -}}

--- a/internal/format/templates/pretty.tmpl
+++ b/internal/format/templates/pretty.tmpl
@@ -1,0 +1,73 @@
+{{- if .Settings.ShowHeader -}}
+    {{- with .Module.Header -}}
+        {{ colorize "\033[90m" . }}
+    {{ end -}}
+    {{- printf "\n\n" -}}
+{{ end -}}
+
+{{- if .Settings.ShowRequirements -}}
+    {{- with .Module.Requirements }}
+        {{- range . }}
+            {{- $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+            {{- printf "requirement.%s" .Name | colorize "\033[36m" }}{{ $version }}
+        {{ end -}}
+    {{ end -}}
+    {{- printf "\n\n" -}}
+{{ end -}}
+
+{{- if .Settings.ShowProviders -}}
+    {{- with .Module.Providers }}
+        {{- range . }}
+            {{- $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+            {{- printf "provider.%s" .FullName | colorize "\033[36m" }}{{ $version }}
+        {{ end -}}
+    {{ end -}}
+    {{- printf "\n\n" -}}
+{{ end -}}
+
+{{- if .Settings.ShowModuleCalls -}}
+    {{- with .Module.ModuleCalls }}
+        {{- range . }}
+            {{- printf "modulecall.%s" .Name | colorize "\033[36m" }}{{ printf " (%s)" .FullName }}
+        {{ end -}}
+        {{- printf "\n\n" -}}
+    {{ end -}}
+{{ end -}}
+
+{{- if .Settings.ShowResources -}}
+    {{- with .Module.Resources }}
+        {{- range . }}
+            {{- if eq (len .URL) 0 }}
+                {{- printf "resource.%s" .FullType | colorize "\033[36m" }}
+            {{- else -}}
+                {{- printf "resource.%s" .FullType | colorize "\033[36m" }} ({{ .URL}})
+            {{- end }}
+        {{ end -}}
+    {{ end -}}
+    {{- printf "\n\n" -}}
+{{ end -}}
+
+{{- if .Settings.ShowInputs -}}
+    {{- with .Module.Inputs }}
+        {{- range . }}
+            {{- printf "input.%s" .Name | colorize "\033[36m" }} ({{ default "required" .GetValue }})
+            {{ tostring .Description | trimSuffix "\n" | default "n/a" | colorize "\033[90m" }}
+            {{- printf "\n\n" -}}
+        {{ end -}}
+    {{ end -}}
+    {{- printf "\n" -}}
+{{ end -}}
+
+{{- if .Settings.ShowOutputs -}}
+    {{- with .Module.Outputs }}
+        {{- range . }}
+            {{- printf "output.%s" .Name | colorize "\033[36m" }}
+            {{- if $.Settings.OutputValues -}}
+                {{- printf " " -}}
+                ({{ ternary .Sensitive "<sensitive>" .GetValue }})
+            {{- end }}
+            {{ tostring .Description | trimSuffix "\n" | default "n/a" | colorize "\033[90m" }}
+            {{- printf "\n\n" -}}
+        {{ end -}}
+    {{ end -}}
+{{ end -}}

--- a/internal/format/templates/tfvars_hcl.tmpl
+++ b/internal/format/templates/tfvars_hcl.tmpl
@@ -1,0 +1,5 @@
+{{- if .Module.Inputs -}}
+    {{- range $i, $k := .Module.Inputs -}}
+        {{ align $k.Name $i }} = {{ value $k.GetValue }}
+    {{ end -}}
+{{- end -}}

--- a/internal/format/tfvars_hcl.go
+++ b/internal/format/tfvars_hcl.go
@@ -11,6 +11,7 @@ the root directory of this source tree.
 package format
 
 import (
+	_ "embed" //nolint
 	"fmt"
 	"reflect"
 	"strings"
@@ -21,15 +22,8 @@ import (
 	"github.com/terraform-docs/terraform-docs/internal/terraform"
 )
 
-const (
-	tfvarsHCLTpl = `
-	{{- if .Module.Inputs -}}
-		{{- range $i, $k := .Module.Inputs -}}
-			{{ align $k.Name $i }} = {{ value $k.GetValue }}
-		{{ end -}}
-	{{- end -}}
-	`
-)
+//go:embed templates/tfvars_hcl.tmpl
+var tfvarsHCLTpl []byte
 
 // TfvarsHCL represents Terraform tfvars HCL format.
 type TfvarsHCL struct {
@@ -42,7 +36,7 @@ var padding []int
 func NewTfvarsHCL(settings *print.Settings) print.Engine {
 	tt := template.New(settings, &template.Item{
 		Name: "tfvars",
-		Text: tfvarsHCLTpl,
+		Text: string(tfvarsHCLTpl),
 	})
 	tt.CustomFunc(gotemplate.FuncMap{
 		"align": func(s string, i int) string {


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Embedding files was added in go1.16, so instead of defining required
templates as constant in .go files, they are moved to dedicated .tmpl
files.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

No extra tests were added, all the existing tests were passed without any modification.

[contribution process]: https://git.io/JtEzg
