### PR TITLE
Add option to hide Type and Default columns

### DIFF
--- a/cmd/asciidoc/asciidoc.go
+++ b/cmd/asciidoc/asciidoc.go
@@ -31,10 +31,12 @@ func NewCommand(config *cli.Config) *cobra.Command {
 	}
 
 	// flags
+	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
+	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
+	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of AsciiDoc sections [1, 2, 3, 4, 5]")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")
-	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of AsciiDoc sections [1, 2, 3, 4, 5]")
-	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
+	cmd.PersistentFlags().BoolVar(&config.Settings.Type, "type", true, "show Type column or section")
 
 	// subcommands
 	cmd.AddCommand(document.NewCommand(config))

--- a/cmd/markdown/markdown.go
+++ b/cmd/markdown/markdown.go
@@ -31,11 +31,13 @@ func NewCommand(config *cli.Config) *cobra.Command {
 	}
 
 	// flags
-	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
-	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")
+	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
+	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Escape, "escape", true, "escape special characters")
 	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of Markdown sections [1, 2, 3, 4, 5]")
-	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
+	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
+	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")
+	cmd.PersistentFlags().BoolVar(&config.Settings.Type, "type", true, "show Type column or section")
 
 	// subcommands
 	cmd.AddCommand(document.NewCommand(config))

--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -27,6 +27,7 @@ terraform-docs asciidoc document [PATH] [flags]
 ```console
       --anchor                      create anchor links (default true)
   -c, --config string               config file name (default ".terraform-docs.yml")
+      --default                     show Default column or section (default true)
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
@@ -40,6 +41,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --sort                        sort items (default true)
       --sort-by-required            sort items by name and print required ones first (default false)
       --sort-by-type                sort items by type of them (default false)
+      --type                        show Type column or section (default true)
 ```
 
 ## Example

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -27,6 +27,7 @@ terraform-docs asciidoc table [PATH] [flags]
 ```console
       --anchor                      create anchor links (default true)
   -c, --config string               config file name (default ".terraform-docs.yml")
+      --default                     show Default column or section (default true)
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
@@ -40,6 +41,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --sort                        sort items (default true)
       --sort-by-required            sort items by name and print required ones first (default false)
       --sort-by-type                sort items by type of them (default false)
+      --type                        show Type column or section (default true)
 ```
 
 ## Example

--- a/docs/reference/asciidoc.md
+++ b/docs/reference/asciidoc.md
@@ -20,10 +20,12 @@ terraform-docs asciidoc [PATH] [flags]
 
 ```console
       --anchor       create anchor links (default true)
+      --default      show Default column or section (default true)
   -h, --help         help for asciidoc
       --indent int   indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --required     show Required column or section (default true)
       --sensitive    show Sensitive column or section (default true)
+      --type         show Type column or section (default true)
 ```
 
 ## Inherited Options

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -38,10 +38,12 @@ sort:
 settings:
   anchors: true
   color: true
+  default: true
   escape: true
   indent: 2
   required: true
   sensitive: true
+  type: true
 ```
 
 **Note:** The following options cannot be used together:

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -27,6 +27,7 @@ terraform-docs markdown document [PATH] [flags]
 ```console
       --anchor                      create anchor links (default true)
   -c, --config string               config file name (default ".terraform-docs.yml")
+      --default                     show Default column or section (default true)
       --escape                      escape special characters (default true)
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [header, inputs, modules, outputs, providers, requirements, resources]
@@ -41,6 +42,7 @@ terraform-docs markdown document [PATH] [flags]
       --sort                        sort items (default true)
       --sort-by-required            sort items by name and print required ones first (default false)
       --sort-by-type                sort items by type of them (default false)
+      --type                        show Type column or section (default true)
 ```
 
 ## Example

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -27,6 +27,7 @@ terraform-docs markdown table [PATH] [flags]
 ```console
       --anchor                      create anchor links (default true)
   -c, --config string               config file name (default ".terraform-docs.yml")
+      --default                     show Default column or section (default true)
       --escape                      escape special characters (default true)
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [header, inputs, modules, outputs, providers, requirements, resources]
@@ -41,6 +42,7 @@ terraform-docs markdown table [PATH] [flags]
       --sort                        sort items (default true)
       --sort-by-required            sort items by name and print required ones first (default false)
       --sort-by-type                sort items by type of them (default false)
+      --type                        show Type column or section (default true)
 ```
 
 ## Example

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -20,11 +20,13 @@ terraform-docs markdown [PATH] [flags]
 
 ```console
       --anchor       create anchor links (default true)
+      --default      show Default column or section (default true)
       --escape       escape special characters (default true)
   -h, --help         help for markdown
       --indent int   indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --required     show Required column or section (default true)
       --sensitive    show Sensitive column or section (default true)
+      --type         show Type column or section (default true)
 ```
 
 ## Inherited Options

--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -14,3 +14,6 @@ sort:
 settings:
   indent: 4
   escape: false
+  default: false
+  required: false
+  type: true

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/terraform-docs/plugin-sdk v0.1.0
+	github.com/terraform-docs/plugin-sdk v0.1.1-0.20210302190742-d48efdc5f937
 	github.com/terraform-docs/terraform-config-inspect v0.0.0-20210126151735-6ef25af8884f
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	honnef.co/go/tools v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/terraform-docs/plugin-sdk v0.1.0 h1:fLoSYS32Oxh3yP1lQsiH7uaf7/vSnbod6QuLBUd4Z+E=
-github.com/terraform-docs/plugin-sdk v0.1.0/go.mod h1:H9E+yVwyOGLXcR28wcWaDODqmhKanZF/uj1H4uCesVM=
+github.com/terraform-docs/plugin-sdk v0.1.1-0.20210302190742-d48efdc5f937 h1:Agy6VTh9FW8xhLbceM0kookCN4+lS1DgbNTZjA/mS04=
+github.com/terraform-docs/plugin-sdk v0.1.1-0.20210302190742-d48efdc5f937/go.mod h1:3G+0nZTeaMF1c5CZh8cOEYeNq0kUL6+DlQOVcxK7eCQ=
 github.com/terraform-docs/terraform-config-inspect v0.0.0-20210126151735-6ef25af8884f h1:WXgHENMC8JOyj6aRpOlnAnJkZ3ZAkPBOhqYrJ5GOhDE=
 github.com/terraform-docs/terraform-config-inspect v0.0.0-20210126151735-6ef25af8884f/go.mod h1:GtanFwTsRRXScYHOMb5h4K18XQBFeS2tXat9/LrPtPc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -160,20 +160,24 @@ func (s *sort) validate() error {
 type settings struct {
 	Anchor    bool `yaml:"anchor"`
 	Color     bool `yaml:"color"`
+	Default   bool `yaml:"default"`
 	Escape    bool `yaml:"escape"`
 	Indent    int  `yaml:"indent"`
 	Required  bool `yaml:"required"`
 	Sensitive bool `yaml:"sensitive"`
+	Type      bool `yaml:"type"`
 }
 
 func defaultSettings() settings {
 	return settings{
 		Anchor:    true,
 		Color:     true,
+		Default:   true,
 		Escape:    true,
 		Indent:    2,
 		Required:  true,
 		Sensitive: true,
+		Type:      true,
 	}
 }
 
@@ -289,10 +293,12 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	// settings
 	settings.EscapeCharacters = c.Settings.Escape
 	settings.IndentLevel = c.Settings.Indent
+	settings.ShowAnchor = c.Settings.Anchor
 	settings.ShowColor = c.Settings.Color
+	settings.ShowDefault = c.Settings.Default
 	settings.ShowRequired = c.Settings.Required
 	settings.ShowSensitivity = c.Settings.Sensitive
-	settings.ShowAnchor = c.Settings.Anchor
+	settings.ShowType = c.Settings.Type
 
 	return settings, options
 }

--- a/internal/cli/reader.go
+++ b/internal/cli/reader.go
@@ -93,7 +93,7 @@ func (c *cfgreader) parse() error {
 			if err := c.overrideValue(mapping[flag], &c.config.OutputValues, &c.overrides.OutputValues); err != nil {
 				return err
 			}
-		case "anchor", "color", "escape", "indent", "required", "sensitive":
+		case "anchor", "color", "default", "escape", "indent", "required", "sensitive", "type":
 			if err := c.overrideValue(flag, &c.config.Settings, &c.overrides.Settings); err != nil {
 				return err
 			}

--- a/internal/format/asciidoc_document_test.go
+++ b/internal/format/asciidoc_document_test.go
@@ -61,6 +61,22 @@ func TestAsciidocDocument(t *testing.T) {
 			),
 			options: terraform.Options{},
 		},
+		"WithoutDefault": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: false,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
+		},
+		"WithoutType": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    false,
+			},
+			options: terraform.Options{},
+		},
 		"IndentationOfFour": {
 			settings: testutil.WithSections(
 				print.Settings{
@@ -98,8 +114,12 @@ func TestAsciidocDocument(t *testing.T) {
 			options:  terraform.Options{},
 		},
 		"OnlyInputs": {
-			settings: print.Settings{ShowInputs: true},
-			options:  terraform.Options{},
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
 		},
 		"OnlyOutputs": {
 			settings: print.Settings{ShowOutputs: true},

--- a/internal/format/asciidoc_table_test.go
+++ b/internal/format/asciidoc_table_test.go
@@ -61,6 +61,22 @@ func TestAsciidocTable(t *testing.T) {
 			),
 			options: terraform.Options{},
 		},
+		"WithoutDefault": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: false,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
+		},
+		"WithoutType": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    false,
+			},
+			options: terraform.Options{},
+		},
 		"IndentationOfFour": {
 			settings: testutil.WithSections(
 				print.Settings{
@@ -98,8 +114,12 @@ func TestAsciidocTable(t *testing.T) {
 			options:  terraform.Options{},
 		},
 		"OnlyInputs": {
-			settings: print.Settings{ShowInputs: true},
-			options:  terraform.Options{},
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
 		},
 		"OnlyOutputs": {
 			settings: print.Settings{ShowOutputs: true},

--- a/internal/format/markdown_document_test.go
+++ b/internal/format/markdown_document_test.go
@@ -61,6 +61,22 @@ func TestMarkdownDocument(t *testing.T) {
 			),
 			options: terraform.Options{},
 		},
+		"WithoutDefault": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: false,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
+		},
+		"WithoutType": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    false,
+			},
+			options: terraform.Options{},
+		},
 		"EscapeCharacters": {
 			settings: testutil.WithSections(
 				print.Settings{
@@ -106,8 +122,12 @@ func TestMarkdownDocument(t *testing.T) {
 			options:  terraform.Options{},
 		},
 		"OnlyInputs": {
-			settings: print.Settings{ShowInputs: true},
-			options:  terraform.Options{},
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
 		},
 		"OnlyOutputs": {
 			settings: print.Settings{ShowOutputs: true},

--- a/internal/format/markdown_table_test.go
+++ b/internal/format/markdown_table_test.go
@@ -61,6 +61,22 @@ func TestMarkdownTable(t *testing.T) {
 			),
 			options: terraform.Options{},
 		},
+		"WithoutDefault": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: false,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
+		},
+		"WithoutType": {
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    false,
+			},
+			options: terraform.Options{},
+		},
 		"EscapeCharacters": {
 			settings: testutil.WithSections(
 				print.Settings{
@@ -106,8 +122,12 @@ func TestMarkdownTable(t *testing.T) {
 			options:  terraform.Options{},
 		},
 		"OnlyInputs": {
-			settings: print.Settings{ShowInputs: true},
-			options:  terraform.Options{},
+			settings: print.Settings{
+				ShowInputs:  true,
+				ShowDefault: true,
+				ShowType:    true,
+			},
+			options: terraform.Options{},
 		},
 		"OnlyOutputs": {
 			settings: print.Settings{ShowOutputs: true},

--- a/internal/format/templates/asciidoc_document.tmpl
+++ b/internal/format/templates/asciidoc_document.tmpl
@@ -77,10 +77,14 @@
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
-                Type: {{ tostring .Type | type }}
+                {{ if $.Settings.ShowType -}}
+                    Type: {{ tostring .Type | type }}
+                {{- end }}
 
-                {{ if or .HasDefault (not isRequired) }}
-                    Default: {{ default "n/a" .GetValue | value }}
+                {{ if $.Settings.ShowDefault }}
+                    {{ if or .HasDefault (not isRequired) }}
+                        Default: {{ default "n/a" .GetValue | value }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -95,10 +99,14 @@
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
-                Type: {{ tostring .Type | type }}
+                {{ if $.Settings.ShowType -}}
+                    Type: {{ tostring .Type | type }}
+                {{- end }}
 
-                {{ if or .HasDefault (not isRequired) }}
-                    Default: {{ default "n/a" .GetValue | value }}
+                {{ if $.Settings.ShowDefault }}
+                    {{ if or .HasDefault (not isRequired) }}
+                        Default: {{ default "n/a" .GetValue | value }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{ end }}
@@ -114,10 +122,14 @@
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
-                Type: {{ tostring .Type | type }}
+                {{ if $.Settings.ShowType -}}
+                    Type: {{ tostring .Type | type }}
+                {{- end }}
 
-                {{ if or .HasDefault (not isRequired) }}
-                    Default: {{ default "n/a" .GetValue | value }}
+                {{ if $.Settings.ShowDefault }}
+                    {{ if or .HasDefault (not isRequired) }}
+                        Default: {{ default "n/a" .GetValue | value }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{ end }}

--- a/internal/format/templates/asciidoc_table.tmpl
+++ b/internal/format/templates/asciidoc_table.tmpl
@@ -74,15 +74,18 @@
     {{ if not .Module.Inputs }}
         No inputs.
     {{ else }}
-        [cols="a,a,a,a{{ if .Settings.ShowRequired }},a{{ end }}",options="header,autowidth"]
+        [cols="a,a{{ if .Settings.ShowType }},a{{ end }}{{ if .Settings.ShowDefault }},a{{ end }}{{ if .Settings.ShowRequired }},a{{ end }}",options="header,autowidth"]
         |===
-        |Name |Description |Type |Default{{ if .Settings.ShowRequired }} |Required{{ end }}
+        |Name |Description
+        {{- if .Settings.ShowType }} |Type{{ end }}
+        {{- if .Settings.ShowDefault }} |Default{{ end }}
+        {{- if .Settings.ShowRequired }} |Required{{ end }}
         {{- range .Module.Inputs }}
             |{{ anchorNameAsciidoc "input" .Name }}
             |{{ tostring .Description | sanitizeAsciidocTbl }}
-            |{{ tostring .Type | type | sanitizeAsciidocTbl }}
-            |{{ value .GetValue | sanitizeAsciidocTbl }}
-            {{ if $.Settings.ShowRequired }}|{{ ternary .Required "yes" "no" }}{{ end }}
+            {{- if $.Settings.ShowType }}{{ printf "\n" }}|{{ tostring .Type | type | sanitizeAsciidocTbl }}{{ end }}
+            {{- if $.Settings.ShowDefault }}{{ printf "\n" }}|{{ value .GetValue | sanitizeAsciidocTbl }}{{ end }}
+            {{- if $.Settings.ShowRequired }}{{ printf "\n" }}|{{ ternary .Required "yes" "no" }}{{ end }}
         {{ end }}
         |===
     {{ end }}

--- a/internal/format/templates/markdown_document.tmpl
+++ b/internal/format/templates/markdown_document.tmpl
@@ -78,10 +78,14 @@
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
-                Type: {{ tostring .Type | type }}
+                {{ if $.Settings.ShowType -}}
+                    Type: {{ tostring .Type | type }}
+                {{- end }}
 
-                {{ if or .HasDefault (not isRequired) }}
-                    Default: {{ default "n/a" .GetValue | value }}
+                {{ if $.Settings.ShowDefault }}
+                    {{ if or .HasDefault (not isRequired) }}
+                        Default: {{ default "n/a" .GetValue | value }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -96,10 +100,14 @@
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
-                Type: {{ tostring .Type | type }}
+                {{ if $.Settings.ShowType -}}
+                    Type: {{ tostring .Type | type }}
+                {{- end }}
 
-                {{ if or .HasDefault (not isRequired) }}
-                    Default: {{ default "n/a" .GetValue | value }}
+                {{ if $.Settings.ShowDefault }}
+                    {{ if or .HasDefault (not isRequired) }}
+                        Default: {{ default "n/a" .GetValue | value }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{ end }}
@@ -115,10 +123,14 @@
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
-                Type: {{ tostring .Type | type }}
+                {{ if $.Settings.ShowType -}}
+                    Type: {{ tostring .Type | type }}
+                {{- end }}
 
-                {{ if or .HasDefault (not isRequired) }}
-                    Default: {{ default "n/a" .GetValue | value }}
+                {{ if $.Settings.ShowDefault }}
+                    {{ if or .HasDefault (not isRequired) }}
+                        Default: {{ default "n/a" .GetValue | value }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{ end }}

--- a/internal/format/templates/markdown_table.tmpl
+++ b/internal/format/templates/markdown_table.tmpl
@@ -66,10 +66,22 @@
     {{ if not .Module.Inputs }}
         No inputs.
     {{ else }}
-        | Name | Description | Type | Default |{{ if .Settings.ShowRequired }} Required |{{ end }}
-        |------|-------------|------|---------|{{ if .Settings.ShowRequired }}:--------:|{{ end }}
+        | Name | Description |
+        {{- if .Settings.ShowType }} Type |{{ end }}
+        {{- if .Settings.ShowDefault }} Default |{{ end }}
+        {{- if .Settings.ShowRequired }} Required |{{ end }}
+        |------|-------------|
+        {{- if .Settings.ShowType }}------|{{ end }}
+        {{- if .Settings.ShowDefault }}---------|{{ end }}
+        {{- if .Settings.ShowRequired }}:--------:|{{ end }}
         {{- range .Module.Inputs }}
-            | {{ anchorName "input" .Name }} | {{ tostring .Description | sanitizeTbl }} | {{ tostring .Type | type | sanitizeTbl }} | {{ value .GetValue | sanitizeTbl }} |
+            | {{ anchorName "input" .Name }} | {{ tostring .Description | sanitizeTbl }} |
+            {{- if $.Settings.ShowType -}}
+                {{ printf " " }}{{ tostring .Type | type | sanitizeTbl }} |
+            {{- end -}}
+            {{- if $.Settings.ShowDefault -}}
+                {{ printf " " }}{{ value .GetValue | sanitizeTbl }} |
+            {{- end -}}
             {{- if $.Settings.ShowRequired -}}
                 {{ printf " " }}{{ ternary .Required "yes" "no" }} |
             {{- end -}}

--- a/internal/format/testdata/asciidoc/document-WithoutDefault.golden
+++ b/internal/format/testdata/asciidoc/document-WithoutDefault.golden
@@ -1,0 +1,207 @@
+== Inputs
+
+The following input variables are supported:
+
+=== unquoted
+
+Description: n/a
+
+Type: `any`
+
+=== bool-3
+
+Description: n/a
+
+Type: `bool`
+
+=== bool-2
+
+Description: It's bool number two.
+
+Type: `bool`
+
+=== bool-1
+
+Description: It's bool number one.
+
+Type: `bool`
+
+=== string-3
+
+Description: n/a
+
+Type: `string`
+
+=== string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+=== string-1
+
+Description: It's string number one.
+
+Type: `string`
+
+=== string-special-chars
+
+Description: n/a
+
+Type: `string`
+
+=== number-3
+
+Description: n/a
+
+Type: `number`
+
+=== number-4
+
+Description: n/a
+
+Type: `number`
+
+=== number-2
+
+Description: It's number number two.
+
+Type: `number`
+
+=== number-1
+
+Description: It's number number one.
+
+Type: `number`
+
+=== map-3
+
+Description: n/a
+
+Type: `map`
+
+=== map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+=== map-1
+
+Description: It's map number one.
+
+Type: `map`
+
+=== list-3
+
+Description: n/a
+
+Type: `list`
+
+=== list-2
+
+Description: It's list number two.
+
+Type: `list`
+
+=== list-1
+
+Description: It's list number one.
+
+Type: `list`
+
+=== input_with_underscores
+
+Description: A variable with underscores.
+
+Type: `any`
+
+=== input-with-pipe
+
+Description: It includes v1 | v2 | v3
+
+Type: `string`
+
+=== input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Type: `list`
+
+=== long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Type:
+[source,hcl]
+----
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+----
+
+=== no-escape-default-value
+
+Description: The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+
+Type: `string`
+
+=== with-url
+
+Description: The description contains url. https://www.domain.com/foo/bar_baz.html
+
+Type: `string`
+
+=== string_default_empty
+
+Description: n/a
+
+Type: `string`
+
+=== string_default_null
+
+Description: n/a
+
+Type: `string`
+
+=== string_no_default
+
+Description: n/a
+
+Type: `string`
+
+=== number_default_zero
+
+Description: n/a
+
+Type: `number`
+
+=== bool_default_false
+
+Description: n/a
+
+Type: `bool`
+
+=== list_default_empty
+
+Description: n/a
+
+Type: `list(string)`
+
+=== object_default_empty
+
+Description: n/a
+
+Type: `object({})`

--- a/internal/format/testdata/asciidoc/document-WithoutType.golden
+++ b/internal/format/testdata/asciidoc/document-WithoutType.golden
@@ -1,0 +1,238 @@
+== Inputs
+
+The following input variables are supported:
+
+=== unquoted
+
+Description: n/a
+
+Default: n/a
+
+=== bool-3
+
+Description: n/a
+
+Default: `true`
+
+=== bool-2
+
+Description: It's bool number two.
+
+Default: `false`
+
+=== bool-1
+
+Description: It's bool number one.
+
+Default: `true`
+
+=== string-3
+
+Description: n/a
+
+Default: `""`
+
+=== string-2
+
+Description: It's string number two.
+
+Default: n/a
+
+=== string-1
+
+Description: It's string number one.
+
+Default: `"bar"`
+
+=== string-special-chars
+
+Description: n/a
+
+Default: `"\\.<>[]{}_-"`
+
+=== number-3
+
+Description: n/a
+
+Default: `"19"`
+
+=== number-4
+
+Description: n/a
+
+Default: `15.75`
+
+=== number-2
+
+Description: It's number number two.
+
+Default: n/a
+
+=== number-1
+
+Description: It's number number one.
+
+Default: `42`
+
+=== map-3
+
+Description: n/a
+
+Default: `{}`
+
+=== map-2
+
+Description: It's map number two.
+
+Default: n/a
+
+=== map-1
+
+Description: It's map number one.
+
+Default:
+[source,json]
+----
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+----
+
+=== list-3
+
+Description: n/a
+
+Default: `[]`
+
+=== list-2
+
+Description: It's list number two.
+
+Default: n/a
+
+=== list-1
+
+Description: It's list number one.
+
+Default:
+[source,json]
+----
+[
+  "a",
+  "b",
+  "c"
+]
+----
+
+=== input_with_underscores
+
+Description: A variable with underscores.
+
+Default: n/a
+
+=== input-with-pipe
+
+Description: It includes v1 | v2 | v3
+
+Default: `"v1"`
+
+=== input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Default:
+[source,json]
+----
+[
+  "name rack:location"
+]
+----
+
+=== long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Default:
+[source,json]
+----
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+----
+
+=== no-escape-default-value
+
+Description: The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+
+Default: `"VALUE_WITH_UNDERSCORE"`
+
+=== with-url
+
+Description: The description contains url. https://www.domain.com/foo/bar_baz.html
+
+Default: `""`
+
+=== string_default_empty
+
+Description: n/a
+
+Default: `""`
+
+=== string_default_null
+
+Description: n/a
+
+Default: `null`
+
+=== string_no_default
+
+Description: n/a
+
+Default: n/a
+
+=== number_default_zero
+
+Description: n/a
+
+Default: `0`
+
+=== bool_default_false
+
+Description: n/a
+
+Default: `false`
+
+=== list_default_empty
+
+Description: n/a
+
+Default: `[]`
+
+=== object_default_empty
+
+Description: n/a
+
+Default: `{}`

--- a/internal/format/testdata/asciidoc/table-WithoutDefault.golden
+++ b/internal/format/testdata/asciidoc/table-WithoutDefault.golden
@@ -1,0 +1,152 @@
+== Inputs
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type
+|unquoted
+|n/a
+|`any`
+
+|bool-3
+|n/a
+|`bool`
+
+|bool-2
+|It's bool number two.
+|`bool`
+
+|bool-1
+|It's bool number one.
+|`bool`
+
+|string-3
+|n/a
+|`string`
+
+|string-2
+|It's string number two.
+|`string`
+
+|string-1
+|It's string number one.
+|`string`
+
+|string-special-chars
+|n/a
+|`string`
+
+|number-3
+|n/a
+|`number`
+
+|number-4
+|n/a
+|`number`
+
+|number-2
+|It's number number two.
+|`number`
+
+|number-1
+|It's number number one.
+|`number`
+
+|map-3
+|n/a
+|`map`
+
+|map-2
+|It's map number two.
+|`map`
+
+|map-1
+|It's map number one.
+|`map`
+
+|list-3
+|n/a
+|`list`
+
+|list-2
+|It's list number two.
+|`list`
+
+|list-1
+|It's list number one.
+|`list`
+
+|input_with_underscores
+|A variable with underscores.
+|`any`
+
+|input-with-pipe
+|It includes v1 \| v2 \| v3
+|`string`
+
+|input-with-code-block
+|This is a complicated one. We need a newline.  
+And an example in a code block
+[source]
+----
+default     = [
+  "machine rack01:neptune"
+]
+----
+
+|`list`
+
+|long_type
+|This description is itself markdown.
+
+It spans over multiple lines.
+
+|
+
+[source]
+----
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+----
+
+|no-escape-default-value
+|The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+|`string`
+
+|with-url
+|The description contains url. https://www.domain.com/foo/bar_baz.html
+|`string`
+
+|string_default_empty
+|n/a
+|`string`
+
+|string_default_null
+|n/a
+|`string`
+
+|string_no_default
+|n/a
+|`string`
+
+|number_default_zero
+|n/a
+|`number`
+
+|bool_default_false
+|n/a
+|`bool`
+
+|list_default_empty
+|n/a
+|`list(string)`
+
+|object_default_empty
+|n/a
+|`object({})`
+
+|===

--- a/internal/format/testdata/asciidoc/table-WithoutType.golden
+++ b/internal/format/testdata/asciidoc/table-WithoutType.golden
@@ -1,0 +1,186 @@
+== Inputs
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Default
+|unquoted
+|n/a
+|n/a
+
+|bool-3
+|n/a
+|`true`
+
+|bool-2
+|It's bool number two.
+|`false`
+
+|bool-1
+|It's bool number one.
+|`true`
+
+|string-3
+|n/a
+|`""`
+
+|string-2
+|It's string number two.
+|n/a
+
+|string-1
+|It's string number one.
+|`"bar"`
+
+|string-special-chars
+|n/a
+|`"\\.<>[]{}_-"`
+
+|number-3
+|n/a
+|`"19"`
+
+|number-4
+|n/a
+|`15.75`
+
+|number-2
+|It's number number two.
+|n/a
+
+|number-1
+|It's number number one.
+|`42`
+
+|map-3
+|n/a
+|`{}`
+
+|map-2
+|It's map number two.
+|n/a
+
+|map-1
+|It's map number one.
+|
+
+[source]
+----
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+----
+
+|list-3
+|n/a
+|`[]`
+
+|list-2
+|It's list number two.
+|n/a
+
+|list-1
+|It's list number one.
+|
+
+[source]
+----
+[
+  "a",
+  "b",
+  "c"
+]
+----
+
+|input_with_underscores
+|A variable with underscores.
+|n/a
+
+|input-with-pipe
+|It includes v1 \| v2 \| v3
+|`"v1"`
+
+|input-with-code-block
+|This is a complicated one. We need a newline.  
+And an example in a code block
+[source]
+----
+default     = [
+  "machine rack01:neptune"
+]
+----
+
+|
+
+[source]
+----
+[
+  "name rack:location"
+]
+----
+
+|long_type
+|This description is itself markdown.
+
+It spans over multiple lines.
+
+|
+
+[source]
+----
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+----
+
+|no-escape-default-value
+|The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+|`"VALUE_WITH_UNDERSCORE"`
+
+|with-url
+|The description contains url. https://www.domain.com/foo/bar_baz.html
+|`""`
+
+|string_default_empty
+|n/a
+|`""`
+
+|string_default_null
+|n/a
+|`null`
+
+|string_no_default
+|n/a
+|n/a
+
+|number_default_zero
+|n/a
+|`0`
+
+|bool_default_false
+|n/a
+|`false`
+
+|list_default_empty
+|n/a
+|`[]`
+
+|object_default_empty
+|n/a
+|`{}`
+
+|===

--- a/internal/format/testdata/markdown/document-WithoutDefault.golden
+++ b/internal/format/testdata/markdown/document-WithoutDefault.golden
@@ -1,0 +1,207 @@
+## Inputs
+
+The following input variables are supported:
+
+### unquoted
+
+Description: n/a
+
+Type: `any`
+
+### bool-3
+
+Description: n/a
+
+Type: `bool`
+
+### bool-2
+
+Description: It's bool number two.
+
+Type: `bool`
+
+### bool-1
+
+Description: It's bool number one.
+
+Type: `bool`
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+### string-1
+
+Description: It's string number one.
+
+Type: `string`
+
+### string-special-chars
+
+Description: n/a
+
+Type: `string`
+
+### number-3
+
+Description: n/a
+
+Type: `number`
+
+### number-4
+
+Description: n/a
+
+Type: `number`
+
+### number-2
+
+Description: It's number number two.
+
+Type: `number`
+
+### number-1
+
+Description: It's number number one.
+
+Type: `number`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+### map-1
+
+Description: It's map number one.
+
+Type: `map`
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
+
+### list-1
+
+Description: It's list number one.
+
+Type: `list`
+
+### input_with_underscores
+
+Description: A variable with underscores.
+
+Type: `any`
+
+### input-with-pipe
+
+Description: It includes v1 | v2 | v3
+
+Type: `string`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Type: `list`
+
+### long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Type:
+
+```hcl
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+```
+
+### no-escape-default-value
+
+Description: The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+
+Type: `string`
+
+### with-url
+
+Description: The description contains url. https://www.domain.com/foo/bar_baz.html
+
+Type: `string`
+
+### string_default_empty
+
+Description: n/a
+
+Type: `string`
+
+### string_default_null
+
+Description: n/a
+
+Type: `string`
+
+### string_no_default
+
+Description: n/a
+
+Type: `string`
+
+### number_default_zero
+
+Description: n/a
+
+Type: `number`
+
+### bool_default_false
+
+Description: n/a
+
+Type: `bool`
+
+### list_default_empty
+
+Description: n/a
+
+Type: `list(string)`
+
+### object_default_empty
+
+Description: n/a
+
+Type: `object({})`

--- a/internal/format/testdata/markdown/document-WithoutType.golden
+++ b/internal/format/testdata/markdown/document-WithoutType.golden
@@ -1,0 +1,238 @@
+## Inputs
+
+The following input variables are supported:
+
+### unquoted
+
+Description: n/a
+
+Default: n/a
+
+### bool-3
+
+Description: n/a
+
+Default: `true`
+
+### bool-2
+
+Description: It's bool number two.
+
+Default: `false`
+
+### bool-1
+
+Description: It's bool number one.
+
+Default: `true`
+
+### string-3
+
+Description: n/a
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Default: n/a
+
+### string-1
+
+Description: It's string number one.
+
+Default: `"bar"`
+
+### string-special-chars
+
+Description: n/a
+
+Default: `"\\.<>[]{}_-"`
+
+### number-3
+
+Description: n/a
+
+Default: `"19"`
+
+### number-4
+
+Description: n/a
+
+Default: `15.75`
+
+### number-2
+
+Description: It's number number two.
+
+Default: n/a
+
+### number-1
+
+Description: It's number number one.
+
+Default: `42`
+
+### map-3
+
+Description: n/a
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Default: n/a
+
+### map-1
+
+Description: It's map number one.
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Default: n/a
+
+### list-1
+
+Description: It's list number one.
+
+Default:
+
+```json
+[
+  "a",
+  "b",
+  "c"
+]
+```
+
+### input_with_underscores
+
+Description: A variable with underscores.
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 | v2 | v3
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
+
+### long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Default:
+
+```json
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+```
+
+### no-escape-default-value
+
+Description: The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+
+Default: `"VALUE_WITH_UNDERSCORE"`
+
+### with-url
+
+Description: The description contains url. https://www.domain.com/foo/bar_baz.html
+
+Default: `""`
+
+### string_default_empty
+
+Description: n/a
+
+Default: `""`
+
+### string_default_null
+
+Description: n/a
+
+Default: `null`
+
+### string_no_default
+
+Description: n/a
+
+Default: n/a
+
+### number_default_zero
+
+Description: n/a
+
+Default: `0`
+
+### bool_default_false
+
+Description: n/a
+
+Default: `false`
+
+### list_default_empty
+
+Description: n/a
+
+Default: `[]`
+
+### object_default_empty
+
+Description: n/a
+
+Default: `{}`

--- a/internal/format/testdata/markdown/table-WithoutDefault.golden
+++ b/internal/format/testdata/markdown/table-WithoutDefault.golden
@@ -1,0 +1,35 @@
+## Inputs
+
+| Name | Description | Type |
+|------|-------------|------|
+| unquoted | n/a | `any` |
+| bool-3 | n/a | `bool` |
+| bool-2 | It's bool number two. | `bool` |
+| bool-1 | It's bool number one. | `bool` |
+| string-3 | n/a | `string` |
+| string-2 | It's string number two. | `string` |
+| string-1 | It's string number one. | `string` |
+| string-special-chars | n/a | `string` |
+| number-3 | n/a | `number` |
+| number-4 | n/a | `number` |
+| number-2 | It's number number two. | `number` |
+| number-1 | It's number number one. | `number` |
+| map-3 | n/a | `map` |
+| map-2 | It's map number two. | `map` |
+| map-1 | It's map number one. | `map` |
+| list-3 | n/a | `list` |
+| list-2 | It's list number two. | `list` |
+| list-1 | It's list number one. | `list` |
+| input_with_underscores | A variable with underscores. | `any` |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> |
+| no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` |
+| with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` |
+| string_default_empty | n/a | `string` |
+| string_default_null | n/a | `string` |
+| string_no_default | n/a | `string` |
+| number_default_zero | n/a | `number` |
+| bool_default_false | n/a | `bool` |
+| list_default_empty | n/a | `list(string)` |
+| object_default_empty | n/a | `object({})` |

--- a/internal/format/testdata/markdown/table-WithoutType.golden
+++ b/internal/format/testdata/markdown/table-WithoutType.golden
@@ -1,0 +1,35 @@
+## Inputs
+
+| Name | Description | Default |
+|------|-------------|---------|
+| unquoted | n/a | n/a |
+| bool-3 | n/a | `true` |
+| bool-2 | It's bool number two. | `false` |
+| bool-1 | It's bool number one. | `true` |
+| string-3 | n/a | `""` |
+| string-2 | It's string number two. | n/a |
+| string-1 | It's string number one. | `"bar"` |
+| string-special-chars | n/a | `"\\.<>[]{}_-"` |
+| number-3 | n/a | `"19"` |
+| number-4 | n/a | `15.75` |
+| number-2 | It's number number two. | n/a |
+| number-1 | It's number number one. | `42` |
+| map-3 | n/a | `{}` |
+| map-2 | It's map number two. | n/a |
+| map-1 | It's map number one. | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
+| list-3 | n/a | `[]` |
+| list-2 | It's list number two. | n/a |
+| list-1 | It's list number one. | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
+| input_with_underscores | A variable with underscores. | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
+| no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `"VALUE_WITH_UNDERSCORE"` |
+| with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `""` |
+| string_default_empty | n/a | `""` |
+| string_default_null | n/a | `null` |
+| string_no_default | n/a | n/a |
+| number_default_zero | n/a | `0` |
+| bool_default_false | n/a | `false` |
+| list_default_empty | n/a | `[]` |
+| object_default_empty | n/a | `{}` |

--- a/internal/print/settings.go
+++ b/internal/print/settings.go
@@ -22,7 +22,7 @@ type Settings struct {
 	// scope: Markdown
 	EscapeCharacters bool
 
-	// IndentLevel control the indentation of AsciiDoc and Markdown headers [available: 1, 2, 3, 4, 5]
+	// IndentLevel control the indentation of headers [available: 1, 2, 3, 4, 5]
 	//
 	// default: 2
 	// scope: Asciidoc, Markdown
@@ -46,6 +46,12 @@ type Settings struct {
 	// scope: Pretty
 	ShowColor bool
 
+	// ShowDefault show "Default" column
+	//
+	// default: true
+	// scope: Asciidoc, Markdown
+	ShowDefault bool
+
 	// ShowHeader show "Header" module information
 	//
 	// default: true
@@ -58,7 +64,7 @@ type Settings struct {
 	// scope: Global
 	ShowInputs bool
 
-	// ShowModuleCalls show "ModuleCalls" information (default: true)
+	// ShowModuleCalls show "ModuleCalls" information
 	//
 	// default: true
 	// scope: Global
@@ -76,16 +82,16 @@ type Settings struct {
 	// scope: Global
 	ShowProviders bool
 
-	// ShowRequired show "Required" column when generating Markdown
+	// ShowRequired show "Required" column
 	//
 	// default: true
-	// scope: Markdown
+	// scope: Asciidoc, Markdown
 	ShowRequired bool
 
-	// ShowSensitivity show "Sensitive" column when generating Markdown
+	// ShowSensitivity show "Sensitive" column
 	//
 	// default: true
-	// scope: Markdown
+	// scope: Asciidoc, Markdown
 	ShowSensitivity bool
 
 	// ShowRequirements show "Requirements" section
@@ -99,6 +105,12 @@ type Settings struct {
 	// default: true
 	// scope: Global
 	ShowResources bool
+
+	// ShowType show "Type" column
+	//
+	// default: true
+	// scope: Asciidoc, Markdown
+	ShowType bool
 }
 
 // DefaultSettings returns new instance of Settings
@@ -109,6 +121,7 @@ func DefaultSettings() *Settings {
 		OutputValues:     false,
 		ShowAnchor:       true,
 		ShowColor:        true,
+		ShowDefault:      true,
 		ShowHeader:       true,
 		ShowInputs:       true,
 		ShowModuleCalls:  true,
@@ -118,6 +131,7 @@ func DefaultSettings() *Settings {
 		ShowSensitivity:  true,
 		ShowRequirements: true,
 		ShowResources:    true,
+		ShowType:         true,
 	}
 }
 
@@ -128,6 +142,7 @@ func (s *Settings) Convert() *printsdk.Settings {
 		IndentLevel:      s.IndentLevel,
 		OutputValues:     s.OutputValues,
 		ShowColor:        s.ShowColor,
+		ShowDefault:      s.ShowDefault,
 		ShowHeader:       s.ShowHeader,
 		ShowInputs:       s.ShowInputs,
 		ShowOutputs:      s.ShowOutputs,
@@ -137,5 +152,6 @@ func (s *Settings) Convert() *printsdk.Settings {
 		ShowSensitivity:  s.ShowSensitivity,
 		ShowRequirements: s.ShowRequirements,
 		ShowResources:    s.ShowResources,
+		ShowType:         s.ShowType,
 	}
 }

--- a/internal/testutil/settings.go
+++ b/internal/testutil/settings.go
@@ -26,6 +26,9 @@ func WithSections(override ...print.Settings) print.Settings {
 		ShowProviders:    true,
 		ShowRequirements: true,
 		ShowResources:    true,
+
+		ShowDefault: true,
+		ShowType:    true,
 	}
 	if len(override) != 1 {
 		return base


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Two new flags are added: '--default bool' and '--type bool' to
control the visibility of Default and Type columns and section
respectively in Markdown and AsciiDoc.

Fixes #312

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Added new `WithoutDefault` and `WithoutType` tests.

[contribution process]: https://git.io/JtEzg
