### PR TITLE
Feat/add resource mode to generated docs

### DIFF
--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -143,10 +143,10 @@ generates the following output:
 
     The following resources are used by this module:
 
-    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-    - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-    - https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+    - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
+    - https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
+    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
+    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)
 
     == Required Inputs
 

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -128,13 +128,13 @@ generates the following output:
 
     == Resources
 
-    [cols="a",options="header,autowidth"]
+    [cols="a,a",options="header,autowidth"]
     |===
-    |Name
-    |https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-    |https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-    |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-    |https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+    |Name |Type
+    |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
+    |https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
+    |https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
+    |https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
     |===
 
     == Inputs

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -371,22 +371,6 @@ generates the following output:
       ],
       "resources": [
         {
-          "type": "caller_identity",
-          "name": "current",
-          "providerName": "aws",
-          "provicerSource": "hashicorp/aws",
-          "mode": "data",
-          "version": "latest"
-        },
-        {
-          "type": "caller_identity",
-          "name": "ident",
-          "providerName": "aws",
-          "provicerSource": "hashicorp/aws",
-          "mode": "data",
-          "version": "latest"
-        },
-        {
           "type": "resource",
           "name": "foo",
           "providerName": "null",
@@ -400,6 +384,22 @@ generates the following output:
           "providerName": "tls",
           "provicerSource": "hashicorp/tls",
           "mode": "managed",
+          "version": "latest"
+        },
+        {
+          "type": "caller_identity",
+          "name": "current",
+          "providerName": "aws",
+          "provicerSource": "hashicorp/aws",
+          "mode": "data",
+          "version": "latest"
+        },
+        {
+          "type": "caller_identity",
+          "name": "ident",
+          "providerName": "aws",
+          "provicerSource": "hashicorp/aws",
+          "mode": "data",
           "version": "latest"
         }
       ]

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -144,10 +144,10 @@ generates the following output:
 
     The following resources are used by this module:
 
-    - [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-    - [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-    - [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-    - [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+    - [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+    - [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+    - [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+    - [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
 
     ## Required Inputs
 

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -123,12 +123,12 @@ generates the following output:
 
     ## Resources
 
-    | Name |
-    |------|
-    | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-    | [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-    | [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-    | [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+    | Name | Type |
+    |------|------|
+    | [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+    | [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+    | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+    | [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
     ## Inputs
 

--- a/docs/reference/pretty.md
+++ b/docs/reference/pretty.md
@@ -107,10 +107,10 @@ generates the following output:
     modulecall.foo (bar,1.2.3)
 
 
-    resource.aws_caller_identity.current (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-    resource.aws_caller_identity.ident (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-    resource.null_resource.foo (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-    resource.tls_private_key.baz (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+    resource.null_resource.foo (resource) (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
+    resource.tls_private_key.baz (resource) (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+    resource.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+    resource.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
 
 
     input.bool-1 (true)

--- a/docs/reference/toml.md
+++ b/docs/reference/toml.md
@@ -346,22 +346,6 @@ generates the following output:
       Version = ">= 2.2.0"
 
     [[resources]]
-      type = "caller_identity"
-      name = "current"
-      providerName = "aws"
-      providerSource = "hashicorp/aws"
-      mode = "data"
-      version = "latest"
-
-    [[resources]]
-      type = "caller_identity"
-      name = "ident"
-      providerName = "aws"
-      providerSource = "hashicorp/aws"
-      mode = "data"
-      version = "latest"
-
-    [[resources]]
       type = "resource"
       name = "foo"
       providerName = "null"
@@ -375,6 +359,22 @@ generates the following output:
       providerName = "tls"
       providerSource = "hashicorp/tls"
       mode = "managed"
+      version = "latest"
+
+    [[resources]]
+      type = "caller_identity"
+      name = "current"
+      providerName = "aws"
+      providerSource = "hashicorp/aws"
+      mode = "data"
+      version = "latest"
+
+    [[resources]]
+      type = "caller_identity"
+      name = "ident"
+      providerName = "aws"
+      providerSource = "hashicorp/aws"
+      mode = "data"
       version = "latest"
 
 [examples]: https://github.com/terraform-docs/terraform-docs/tree/master/examples

--- a/docs/reference/xml.md
+++ b/docs/reference/xml.md
@@ -370,22 +370,6 @@ generates the following output:
       </requirements>
       <resources>
         <resource>
-          <type>caller_identity</type>
-          <name>current</name>
-          <providerName>aws</providerName>
-          <providerSource>hashicorp/aws</providerSource>
-          <mode>data</mode>
-          <version>latest</version>
-        </resource>
-        <resource>
-          <type>caller_identity</type>
-          <name>ident</name>
-          <providerName>aws</providerName>
-          <providerSource>hashicorp/aws</providerSource>
-          <mode>data</mode>
-          <version>latest</version>
-        </resource>
-        <resource>
           <type>resource</type>
           <name>foo</name>
           <providerName>null</providerName>
@@ -399,6 +383,22 @@ generates the following output:
           <providerName>tls</providerName>
           <providerSource>hashicorp/tls</providerSource>
           <mode>managed</mode>
+          <version>latest</version>
+        </resource>
+        <resource>
+          <type>caller_identity</type>
+          <name>current</name>
+          <providerName>aws</providerName>
+          <providerSource>hashicorp/aws</providerSource>
+          <mode>data</mode>
+          <version>latest</version>
+        </resource>
+        <resource>
+          <type>caller_identity</type>
+          <name>ident</name>
+          <providerName>aws</providerName>
+          <providerSource>hashicorp/aws</providerSource>
+          <mode>data</mode>
           <version>latest</version>
         </resource>
       </resources>

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -313,18 +313,6 @@ generates the following output:
       - name: random
         version: '>= 2.2.0'
     resources:
-      - type: caller_identity
-        name: current
-        providerName: aws
-        providerSource: hashicorp/aws
-        mode: data
-        version: latest
-      - type: caller_identity
-        name: ident
-        providerName: aws
-        providerSource: hashicorp/aws
-        mode: data
-        version: latest
       - type: resource
         name: foo
         providerName: "null"
@@ -336,6 +324,18 @@ generates the following output:
         providerName: tls
         providerSource: hashicorp/tls
         mode: managed
+        version: latest
+      - type: caller_identity
+        name: current
+        providerName: aws
+        providerSource: hashicorp/aws
+        mode: data
+        version: latest
+      - type: caller_identity
+        name: ident
+        providerName: aws
+        providerSource: hashicorp/aws
+        mode: data
         version: latest
 
 [examples]: https://github.com/terraform-docs/terraform-docs/tree/master/examples

--- a/internal/format/common_test.go
+++ b/internal/format/common_test.go
@@ -92,7 +92,7 @@ func TestCommonSort(t *testing.T) {
 				assert.Equal(expected.Requirements[ii], r.Name)
 			}
 			for ii, r := range module.Resources {
-				assert.Equal(expected.Resources[ii], r.FullType()+"__"+r.Mode+"."+r.Name)
+				assert.Equal(expected.Resources[ii], r.Spec()+"__"+r.Mode)
 			}
 		})
 	}

--- a/internal/format/templates/asciidoc_document.tmpl
+++ b/internal/format/templates/asciidoc_document.tmpl
@@ -56,9 +56,9 @@
         The following resources are used by this module:
         {{ range .Module.Resources }}
             {{ if eq (len .URL) 0 }}
-            - {{ .FullType }}.{{ .Name }}
+            - {{ .Spec }} {{ printf "(%s)" .GetMode -}}
             {{- else -}}
-            - {{ .URL }}[{{ .FullType }}.{{ .Name }}]
+            - {{ .URL }}[{{ .Spec }}] {{ printf "(%s)" .GetMode -}}
             {{- end }}
         {{- end }}
     {{ end }}

--- a/internal/format/templates/asciidoc_table.tmpl
+++ b/internal/format/templates/asciidoc_table.tmpl
@@ -55,14 +55,14 @@
     {{ if not .Module.Resources }}
         No resources.
     {{ else }}
-        [cols="a",options="header,autowidth"]
+        [cols="a,a",options="header,autowidth"]
         |===
-        |Name
+        |Name |Type
         {{- range .Module.Resources }}
             {{ if eq (len .URL) 0 }}
-            |{{ .FullType }}.{{ .Name }}
+                |{{ .Spec }} |{{ .GetMode }}
             {{- else -}}
-            |{{ .URL }}[{{ .FullType }}.{{ .Name }}]
+                |{{ .URL }}[{{ .Spec }}] |{{ .GetMode }}
             {{- end }}
         {{- end }}
         |===

--- a/internal/format/templates/markdown_document.tmpl
+++ b/internal/format/templates/markdown_document.tmpl
@@ -57,9 +57,9 @@
         The following resources are used by this module:
         {{ range .Module.Resources }}
             {{ if eq (len .URL) 0 }}
-            - {{ .FullType }}.{{ .Name }}
+                - {{ .Spec }} {{ printf "(%s)" .GetMode -}}
             {{- else -}}
-            - [{{ .FullType }}.{{ .Name }}]({{ .URL }})
+                - [{{ .Spec }}]({{ .URL }}) {{ printf "(%s)" .GetMode -}}
             {{- end }}
         {{- end }}
     {{ end }}

--- a/internal/format/templates/markdown_table.tmpl
+++ b/internal/format/templates/markdown_table.tmpl
@@ -49,14 +49,14 @@
     {{ if not .Module.Resources }}
         No resources.
     {{ else }}
-        | Name |
-        |------|
+        | Name | Type |
+        |------|------|
         {{- range .Module.Resources }}
-        {{ if eq (len .URL) 0 }}
-            | {{ .FullType }}.{{ .Name }} |
-        {{- else -}}
-            | [{{ .FullType }}.{{ .Name }}]({{ .URL }}) |
-        {{- end }}
+            {{ if eq (len .URL) 0 }}
+                | {{ .Spec }} | {{ .GetMode }} |
+            {{- else -}}
+                | [{{ .Spec }}]({{ .URL }}) | {{ .GetMode }} |
+            {{- end }}
         {{- end }}
     {{ end }}
 {{ end -}}

--- a/internal/format/templates/pretty.tmpl
+++ b/internal/format/templates/pretty.tmpl
@@ -38,9 +38,9 @@
     {{- with .Module.Resources }}
         {{- range . }}
             {{- if eq (len .URL) 0 }}
-                {{- printf "resource.%s.%s" .FullType .Name | colorize "\033[36m" }}
+                {{- printf "resource.%s (%s)" .Spec .GetMode | colorize "\033[36m" }}
             {{- else -}}
-                {{- printf "resource.%s.%s" .FullType .Name | colorize "\033[36m" }} ({{ .URL}})
+                {{- printf "resource.%s (%s)" .Spec .GetMode | colorize "\033[36m" }} ({{ .URL}})
             {{- end }}
         {{ end -}}
     {{ end -}}

--- a/internal/format/testdata/asciidoc/document-Base.golden
+++ b/internal/format/testdata/asciidoc/document-Base.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
+- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)
 
 == Inputs
 

--- a/internal/format/testdata/asciidoc/document-IndentationOfFour.golden
+++ b/internal/format/testdata/asciidoc/document-IndentationOfFour.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
+- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)
 
 ==== Inputs
 

--- a/internal/format/testdata/asciidoc/document-OnlyResources.golden
+++ b/internal/format/testdata/asciidoc/document-OnlyResources.golden
@@ -2,7 +2,7 @@
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
+- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)

--- a/internal/format/testdata/asciidoc/document-WithAnchor.golden
+++ b/internal/format/testdata/asciidoc/document-WithAnchor.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
+- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)
 
 == Inputs
 

--- a/internal/format/testdata/asciidoc/document-WithRequired.golden
+++ b/internal/format/testdata/asciidoc/document-WithRequired.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
+- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)
 
 == Required Inputs
 

--- a/internal/format/testdata/asciidoc/table-Base.golden
+++ b/internal/format/testdata/asciidoc/table-Base.golden
@@ -69,13 +69,13 @@ followed by another line of text.
 
 == Resources
 
-[cols="a",options="header,autowidth"]
+[cols="a,a",options="header,autowidth"]
 |===
-|Name
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
 |===
 
 == Inputs

--- a/internal/format/testdata/asciidoc/table-IndentationOfFour.golden
+++ b/internal/format/testdata/asciidoc/table-IndentationOfFour.golden
@@ -69,13 +69,13 @@ followed by another line of text.
 
 ==== Resources
 
-[cols="a",options="header,autowidth"]
+[cols="a,a",options="header,autowidth"]
 |===
-|Name
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
 |===
 
 ==== Inputs

--- a/internal/format/testdata/asciidoc/table-OnlyResources.golden
+++ b/internal/format/testdata/asciidoc/table-OnlyResources.golden
@@ -1,10 +1,10 @@
 == Resources
 
-[cols="a",options="header,autowidth"]
+[cols="a,a",options="header,autowidth"]
 |===
-|Name
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
 |===

--- a/internal/format/testdata/asciidoc/table-WithAnchor.golden
+++ b/internal/format/testdata/asciidoc/table-WithAnchor.golden
@@ -69,13 +69,13 @@ followed by another line of text.
 
 == Resources
 
-[cols="a",options="header,autowidth"]
+[cols="a,a",options="header,autowidth"]
 |===
-|Name
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
 |===
 
 == Inputs

--- a/internal/format/testdata/asciidoc/table-WithRequired.golden
+++ b/internal/format/testdata/asciidoc/table-WithRequired.golden
@@ -69,13 +69,13 @@ followed by another line of text.
 
 == Resources
 
-[cols="a",options="header,autowidth"]
+[cols="a,a",options="header,autowidth"]
 |===
-|Name
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current]
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident]
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo]
-|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz]
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
 |===
 
 == Inputs

--- a/internal/format/testdata/common/sort-NoSort.golden
+++ b/internal/format/testdata/common/sort-NoSort.golden
@@ -55,9 +55,9 @@
     "random"
   ],
   "resources": [
-    "aws_caller_identity__data.current",
-    "aws_caller_identity__data.ident",
-    "null_resource__managed.foo",
-    "tls_private_key__managed.baz"
+    "null_resource.foo__managed",
+    "tls_private_key.baz__managed",
+    "aws_caller_identity.current__data",
+    "aws_caller_identity.ident__data"
   ]
 }

--- a/internal/format/testdata/common/sort-SortByName.golden
+++ b/internal/format/testdata/common/sort-SortByName.golden
@@ -55,9 +55,9 @@
     "random"
   ],
   "resources": [
-    "aws_caller_identity__data.current",
-    "aws_caller_identity__data.ident",
-    "null_resource__managed.foo",
-    "tls_private_key__managed.baz"
+    "null_resource.foo__managed",
+    "tls_private_key.baz__managed",
+    "aws_caller_identity.current__data",
+    "aws_caller_identity.ident__data"
   ]
 }

--- a/internal/format/testdata/common/sort-SortByRequired.golden
+++ b/internal/format/testdata/common/sort-SortByRequired.golden
@@ -55,9 +55,9 @@
     "random"
   ],
   "resources": [
-    "aws_caller_identity__data.current",
-    "aws_caller_identity__data.ident",
-    "null_resource__managed.foo",
-    "tls_private_key__managed.baz"
+    "null_resource.foo__managed",
+    "tls_private_key.baz__managed",
+    "aws_caller_identity.current__data",
+    "aws_caller_identity.ident__data"
   ]
 }

--- a/internal/format/testdata/common/sort-SortByType.golden
+++ b/internal/format/testdata/common/sort-SortByType.golden
@@ -55,9 +55,9 @@
     "random"
   ],
   "resources": [
-    "aws_caller_identity__data.current",
-    "aws_caller_identity__data.ident",
-    "null_resource__managed.foo",
-    "tls_private_key__managed.baz"
+    "null_resource.foo__managed",
+    "tls_private_key.baz__managed",
+    "aws_caller_identity.current__data",
+    "aws_caller_identity.ident__data"
   ]
 }

--- a/internal/format/testdata/json/json-Base.golden
+++ b/internal/format/testdata/json/json-Base.golden
@@ -317,22 +317,6 @@
   ],
   "resources": [
     {
-      "type": "caller_identity",
-      "name": "current",
-      "providerName": "aws",
-      "provicerSource": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
-    },
-    {
-      "type": "caller_identity",
-      "name": "ident",
-      "providerName": "aws",
-      "provicerSource": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
-    },
-    {
       "type": "resource",
       "name": "foo",
       "providerName": "null",
@@ -346,6 +330,22 @@
       "providerName": "tls",
       "provicerSource": "hashicorp/tls",
       "mode": "managed",
+      "version": "latest"
+    },
+    {
+      "type": "caller_identity",
+      "name": "current",
+      "providerName": "aws",
+      "provicerSource": "hashicorp/aws",
+      "mode": "data",
+      "version": "latest"
+    },
+    {
+      "type": "caller_identity",
+      "name": "ident",
+      "providerName": "aws",
+      "provicerSource": "hashicorp/aws",
+      "mode": "data",
       "version": "latest"
     }
   ]

--- a/internal/format/testdata/json/json-EscapeCharacters.golden
+++ b/internal/format/testdata/json/json-EscapeCharacters.golden
@@ -317,22 +317,6 @@
   ],
   "resources": [
     {
-      "type": "caller_identity",
-      "name": "current",
-      "providerName": "aws",
-      "provicerSource": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
-    },
-    {
-      "type": "caller_identity",
-      "name": "ident",
-      "providerName": "aws",
-      "provicerSource": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
-    },
-    {
       "type": "resource",
       "name": "foo",
       "providerName": "null",
@@ -346,6 +330,22 @@
       "providerName": "tls",
       "provicerSource": "hashicorp/tls",
       "mode": "managed",
+      "version": "latest"
+    },
+    {
+      "type": "caller_identity",
+      "name": "current",
+      "providerName": "aws",
+      "provicerSource": "hashicorp/aws",
+      "mode": "data",
+      "version": "latest"
+    },
+    {
+      "type": "caller_identity",
+      "name": "ident",
+      "providerName": "aws",
+      "provicerSource": "hashicorp/aws",
+      "mode": "data",
       "version": "latest"
     }
   ]

--- a/internal/format/testdata/json/json-OnlyResources.golden
+++ b/internal/format/testdata/json/json-OnlyResources.golden
@@ -7,22 +7,6 @@
   "requirements": [],
   "resources": [
     {
-      "type": "caller_identity",
-      "name": "current",
-      "providerName": "aws",
-      "provicerSource": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
-    },
-    {
-      "type": "caller_identity",
-      "name": "ident",
-      "providerName": "aws",
-      "provicerSource": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
-    },
-    {
       "type": "resource",
       "name": "foo",
       "providerName": "null",
@@ -36,6 +20,22 @@
       "providerName": "tls",
       "provicerSource": "hashicorp/tls",
       "mode": "managed",
+      "version": "latest"
+    },
+    {
+      "type": "caller_identity",
+      "name": "current",
+      "providerName": "aws",
+      "provicerSource": "hashicorp/aws",
+      "mode": "data",
+      "version": "latest"
+    },
+    {
+      "type": "caller_identity",
+      "name": "ident",
+      "providerName": "aws",
+      "provicerSource": "hashicorp/aws",
+      "mode": "data",
       "version": "latest"
     }
   ]

--- a/internal/format/testdata/markdown/document-Base.golden
+++ b/internal/format/testdata/markdown/document-Base.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
 
 ## Inputs
 

--- a/internal/format/testdata/markdown/document-EscapeCharacters.golden
+++ b/internal/format/testdata/markdown/document-EscapeCharacters.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
 
 ## Inputs
 

--- a/internal/format/testdata/markdown/document-IndentationOfFour.golden
+++ b/internal/format/testdata/markdown/document-IndentationOfFour.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
 
 #### Inputs
 

--- a/internal/format/testdata/markdown/document-OnlyResources.golden
+++ b/internal/format/testdata/markdown/document-OnlyResources.golden
@@ -2,7 +2,7 @@
 
 The following resources are used by this module:
 
-- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)

--- a/internal/format/testdata/markdown/document-WithAnchor.golden
+++ b/internal/format/testdata/markdown/document-WithAnchor.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
 
 ## Inputs
 

--- a/internal/format/testdata/markdown/document-WithRequired.golden
+++ b/internal/format/testdata/markdown/document-WithRequired.golden
@@ -84,10 +84,10 @@ Version: 4.5.6
 
 The following resources are used by this module:
 
-- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
 
 ## Required Inputs
 

--- a/internal/format/testdata/markdown/table-Base.golden
+++ b/internal/format/testdata/markdown/table-Base.golden
@@ -63,12 +63,12 @@ followed by another line of text.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| Name | Type |
+|------|------|
+| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/internal/format/testdata/markdown/table-EscapeCharacters.golden
+++ b/internal/format/testdata/markdown/table-EscapeCharacters.golden
@@ -63,12 +63,12 @@ followed by another line of text.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| Name | Type |
+|------|------|
+| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/internal/format/testdata/markdown/table-IndentationOfFour.golden
+++ b/internal/format/testdata/markdown/table-IndentationOfFour.golden
@@ -63,12 +63,12 @@ followed by another line of text.
 
 #### Resources
 
-| Name |
-|------|
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| Name | Type |
+|------|------|
+| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 #### Inputs
 

--- a/internal/format/testdata/markdown/table-OnlyResources.golden
+++ b/internal/format/testdata/markdown/table-OnlyResources.golden
@@ -1,8 +1,8 @@
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| Name | Type |
+|------|------|
+| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/internal/format/testdata/markdown/table-WithAnchor.golden
+++ b/internal/format/testdata/markdown/table-WithAnchor.golden
@@ -63,12 +63,12 @@ followed by another line of text.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| Name | Type |
+|------|------|
+| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/internal/format/testdata/markdown/table-WithRequired.golden
+++ b/internal/format/testdata/markdown/table-WithRequired.golden
@@ -63,12 +63,12 @@ followed by another line of text.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| Name | Type |
+|------|------|
+| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/internal/format/testdata/pretty/pretty-Base.golden
+++ b/internal/format/testdata/pretty/pretty-Base.golden
@@ -53,10 +53,10 @@ modulecall.bar (baz,4.5.6)
 modulecall.baz (baz,4.5.6)
 
 
-resource.aws_caller_identity.current (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-resource.aws_caller_identity.ident (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-resource.null_resource.foo (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-resource.tls_private_key.baz (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+resource.null_resource.foo (resource) (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
+resource.tls_private_key.baz (resource) (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+resource.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+resource.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
 
 
 input.unquoted (required)

--- a/internal/format/testdata/pretty/pretty-OnlyResources.golden
+++ b/internal/format/testdata/pretty/pretty-OnlyResources.golden
@@ -1,4 +1,4 @@
-resource.aws_caller_identity.current (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-resource.aws_caller_identity.ident (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-resource.null_resource.foo (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-resource.tls_private_key.baz (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+resource.null_resource.foo (resource) (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
+resource.tls_private_key.baz (resource) (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+resource.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+resource.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)

--- a/internal/format/testdata/pretty/pretty-WithColor.golden
+++ b/internal/format/testdata/pretty/pretty-WithColor.golden
@@ -53,10 +53,10 @@ followed by another line of text.
 [36mmodulecall.baz[0m (baz,4.5.6)
 
 
-[36mresource.aws_caller_identity.current[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-[36mresource.aws_caller_identity.ident[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-[36mresource.null_resource.foo[0m (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
-[36mresource.tls_private_key.baz[0m (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+[36mresource.null_resource.foo (resource)[0m (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
+[36mresource.tls_private_key.baz (resource)[0m (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+[36mresource.aws_caller_identity.current (data source)[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+[36mresource.aws_caller_identity.ident (data source)[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
 
 
 [36minput.unquoted[0m (required)

--- a/internal/format/testdata/toml/toml-Base.golden
+++ b/internal/format/testdata/toml/toml-Base.golden
@@ -293,22 +293,6 @@ header = "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 
   Version = ">= 2.2.0"
 
 [[resources]]
-  type = "caller_identity"
-  name = "current"
-  providerName = "aws"
-  providerSource = "hashicorp/aws"
-  mode = "data"
-  version = "latest"
-
-[[resources]]
-  type = "caller_identity"
-  name = "ident"
-  providerName = "aws"
-  providerSource = "hashicorp/aws"
-  mode = "data"
-  version = "latest"
-
-[[resources]]
   type = "resource"
   name = "foo"
   providerName = "null"
@@ -322,4 +306,20 @@ header = "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 
   providerName = "tls"
   providerSource = "hashicorp/tls"
   mode = "managed"
+  version = "latest"
+
+[[resources]]
+  type = "caller_identity"
+  name = "current"
+  providerName = "aws"
+  providerSource = "hashicorp/aws"
+  mode = "data"
+  version = "latest"
+
+[[resources]]
+  type = "caller_identity"
+  name = "ident"
+  providerName = "aws"
+  providerSource = "hashicorp/aws"
+  mode = "data"
   version = "latest"

--- a/internal/format/testdata/toml/toml-OnlyResources.golden
+++ b/internal/format/testdata/toml/toml-OnlyResources.golden
@@ -6,22 +6,6 @@ providers = []
 requirements = []
 
 [[resources]]
-  type = "caller_identity"
-  name = "current"
-  providerName = "aws"
-  providerSource = "hashicorp/aws"
-  mode = "data"
-  version = "latest"
-
-[[resources]]
-  type = "caller_identity"
-  name = "ident"
-  providerName = "aws"
-  providerSource = "hashicorp/aws"
-  mode = "data"
-  version = "latest"
-
-[[resources]]
   type = "resource"
   name = "foo"
   providerName = "null"
@@ -35,4 +19,20 @@ requirements = []
   providerName = "tls"
   providerSource = "hashicorp/tls"
   mode = "managed"
+  version = "latest"
+
+[[resources]]
+  type = "caller_identity"
+  name = "current"
+  providerName = "aws"
+  providerSource = "hashicorp/aws"
+  mode = "data"
+  version = "latest"
+
+[[resources]]
+  type = "caller_identity"
+  name = "ident"
+  providerName = "aws"
+  providerSource = "hashicorp/aws"
+  mode = "data"
   version = "latest"

--- a/internal/format/testdata/xml/xml-Base.golden
+++ b/internal/format/testdata/xml/xml-Base.golden
@@ -317,22 +317,6 @@
   </requirements>
   <resources>
     <resource>
-      <type>caller_identity</type>
-      <name>current</name>
-      <providerName>aws</providerName>
-      <providerSource>hashicorp/aws</providerSource>
-      <mode>data</mode>
-      <version>latest</version>
-    </resource>
-    <resource>
-      <type>caller_identity</type>
-      <name>ident</name>
-      <providerName>aws</providerName>
-      <providerSource>hashicorp/aws</providerSource>
-      <mode>data</mode>
-      <version>latest</version>
-    </resource>
-    <resource>
       <type>resource</type>
       <name>foo</name>
       <providerName>null</providerName>
@@ -346,6 +330,22 @@
       <providerName>tls</providerName>
       <providerSource>hashicorp/tls</providerSource>
       <mode>managed</mode>
+      <version>latest</version>
+    </resource>
+    <resource>
+      <type>caller_identity</type>
+      <name>current</name>
+      <providerName>aws</providerName>
+      <providerSource>hashicorp/aws</providerSource>
+      <mode>data</mode>
+      <version>latest</version>
+    </resource>
+    <resource>
+      <type>caller_identity</type>
+      <name>ident</name>
+      <providerName>aws</providerName>
+      <providerSource>hashicorp/aws</providerSource>
+      <mode>data</mode>
       <version>latest</version>
     </resource>
   </resources>

--- a/internal/format/testdata/xml/xml-OnlyResources.golden
+++ b/internal/format/testdata/xml/xml-OnlyResources.golden
@@ -7,22 +7,6 @@
   <requirements></requirements>
   <resources>
     <resource>
-      <type>caller_identity</type>
-      <name>current</name>
-      <providerName>aws</providerName>
-      <providerSource>hashicorp/aws</providerSource>
-      <mode>data</mode>
-      <version>latest</version>
-    </resource>
-    <resource>
-      <type>caller_identity</type>
-      <name>ident</name>
-      <providerName>aws</providerName>
-      <providerSource>hashicorp/aws</providerSource>
-      <mode>data</mode>
-      <version>latest</version>
-    </resource>
-    <resource>
       <type>resource</type>
       <name>foo</name>
       <providerName>null</providerName>
@@ -36,6 +20,22 @@
       <providerName>tls</providerName>
       <providerSource>hashicorp/tls</providerSource>
       <mode>managed</mode>
+      <version>latest</version>
+    </resource>
+    <resource>
+      <type>caller_identity</type>
+      <name>current</name>
+      <providerName>aws</providerName>
+      <providerSource>hashicorp/aws</providerSource>
+      <mode>data</mode>
+      <version>latest</version>
+    </resource>
+    <resource>
+      <type>caller_identity</type>
+      <name>ident</name>
+      <providerName>aws</providerName>
+      <providerSource>hashicorp/aws</providerSource>
+      <mode>data</mode>
       <version>latest</version>
     </resource>
   </resources>

--- a/internal/format/testdata/yaml/yaml-Base.golden
+++ b/internal/format/testdata/yaml/yaml-Base.golden
@@ -260,18 +260,6 @@ requirements:
   - name: random
     version: '>= 2.2.0'
 resources:
-  - type: caller_identity
-    name: current
-    providerName: aws
-    providerSource: hashicorp/aws
-    mode: data
-    version: latest
-  - type: caller_identity
-    name: ident
-    providerName: aws
-    providerSource: hashicorp/aws
-    mode: data
-    version: latest
   - type: resource
     name: foo
     providerName: "null"
@@ -283,4 +271,16 @@ resources:
     providerName: tls
     providerSource: hashicorp/tls
     mode: managed
+    version: latest
+  - type: caller_identity
+    name: current
+    providerName: aws
+    providerSource: hashicorp/aws
+    mode: data
+    version: latest
+  - type: caller_identity
+    name: ident
+    providerName: aws
+    providerSource: hashicorp/aws
+    mode: data
     version: latest

--- a/internal/format/testdata/yaml/yaml-OnlyResources.golden
+++ b/internal/format/testdata/yaml/yaml-OnlyResources.golden
@@ -5,18 +5,6 @@ outputs: []
 providers: []
 requirements: []
 resources:
-  - type: caller_identity
-    name: current
-    providerName: aws
-    providerSource: hashicorp/aws
-    mode: data
-    version: latest
-  - type: caller_identity
-    name: ident
-    providerName: aws
-    providerSource: hashicorp/aws
-    mode: data
-    version: latest
   - type: resource
     name: foo
     providerName: "null"
@@ -28,4 +16,16 @@ resources:
     providerName: tls
     providerSource: hashicorp/tls
     mode: managed
+    version: latest
+  - type: caller_identity
+    name: current
+    providerName: aws
+    providerSource: hashicorp/aws
+    mode: data
+    version: latest
+  - type: caller_identity
+    name: ident
+    providerName: aws
+    providerSource: hashicorp/aws
+    mode: data
     version: latest


### PR DESCRIPTION
### Description of your changes

Fixes #412

With this pull request, we add to the generated docs, the resource type column, as resource or data source

### Notes

1. why the FullType function has been renamed to Spec?
  → with the addition of Name to function, the previous name was weird
  → the hashicorp defines the `<provider>_<resource type>.<resource name>` as [Resource Spec](https://www.terraform.io/docs/cli/state/resource-addressing.html#resource-spec)

2. This PR has changes in json, toml, xml and yaml outputs just because the output sort has been changed to:
  → Always sort by `<Mode> (Data Source < Resource)`, then sort by `<ProviderName>_<Type>.<Name>`

3. This PR was implement with the [suggestion 3](https://github.com/terraform-docs/terraform-docs/issues/412#issuecomment-793219921)

#### Suggestion 3:

→ At the end with parentheses after `<URL>`

→ Always sort by `<Mode>` (resource < data source), then sort by `<ProviderName>_<Type>.<Name>`

- [aws_iam_access_key.lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/aws_iam_access_key) (resource)
- [aws_iam_user_policy.lb_ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) (resource)
- [aws_iam_group.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_group) (data source)
- [aws_iam_user.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_user) (data source)

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

##### `terraform-docs asciidoc document .`
```
== Resources

The following resources are used by this module:

- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
- https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)
```

##### `terraform-docs asciidoc table .`
```
== Resources

[cols="a,a",options="header,autowidth"]
|===
|Name |Type
|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
|https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
|===
```

##### `terraform-docs json .`
```json
  "resources": [
    {
      "type": "resource",
      "name": "foo",
      "providerName": "null",
      "provicerSource": "hashicorp/null",
      "mode": "managed",
      "version": "latest"
    },
    {
      "type": "private_key",
      "name": "baz",
      "providerName": "tls",
      "provicerSource": "hashicorp/tls",
      "mode": "managed",
      "version": "latest"
    },
    {
      "type": "caller_identity",
      "name": "current",
      "providerName": "aws",
      "provicerSource": "hashicorp/aws",
      "mode": "data",
      "version": "latest"
    },
    {
      "type": "caller_identity",
      "name": "ident",
      "providerName": "aws",
      "provicerSource": "hashicorp/aws",
      "mode": "data",
      "version": "latest"
    }
  ]
```

##### `terraform-docs markdown document .`
```markdown
## Resources

The following resources are used by this module:

- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
```

##### `terraform-docs markdown table .`
```markdown
## Resources

| Name | Type |
|------|------|
| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
```

##### `terraform-docs pretty .`
```pretty
resource.null_resource.foo (resource) (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
resource.tls_private_key.baz (resource) (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
resource.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
resource.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
```

##### `terraform-docs toml .`
```toml
[[resources]]
  type = "resource"
  name = "foo"
  providerName = "null"
  providerSource = "hashicorp/null"
  mode = "managed"
  version = "latest"

[[resources]]
  type = "private_key"
  name = "baz"
  providerName = "tls"
  providerSource = "hashicorp/tls"
  mode = "managed"
  version = "latest"

[[resources]]
  type = "caller_identity"
  name = "current"
  providerName = "aws"
  providerSource = "hashicorp/aws"
  mode = "data"
  version = "latest"

[[resources]]
  type = "caller_identity"
  name = "ident"
  providerName = "aws"
  providerSource = "hashicorp/aws"
  mode = "data"
  version = "latest"
```

##### `terraform-docs xml .`
```xml
  <resources>
    <resource>
      <type>resource</type>
      <name>foo</name>
      <providerName>null</providerName>
      <providerSource>hashicorp/null</providerSource>
      <mode>managed</mode>
      <version>latest</version>
    </resource>
    <resource>
      <type>private_key</type>
      <name>baz</name>
      <providerName>tls</providerName>
      <providerSource>hashicorp/tls</providerSource>
      <mode>managed</mode>
      <version>latest</version>
    </resource>
    <resource>
      <type>caller_identity</type>
      <name>current</name>
      <providerName>aws</providerName>
      <providerSource>hashicorp/aws</providerSource>
      <mode>data</mode>
      <version>latest</version>
    </resource>
    <resource>
      <type>caller_identity</type>
      <name>ident</name>
      <providerName>aws</providerName>
      <providerSource>hashicorp/aws</providerSource>
      <mode>data</mode>
      <version>latest</version>
    </resource>
  </resources>
```

##### `terraform-docs yaml .`
```yaml
resources:
  - type: resource
    name: foo
    providerName: "null"
    providerSource: hashicorp/null
    mode: managed
    version: latest
  - type: private_key
    name: baz
    providerName: tls
    providerSource: hashicorp/tls
    mode: managed
    version: latest
  - type: caller_identity
    name: current
    providerName: aws
    providerSource: hashicorp/aws
    mode: data
    version: latest
  - type: caller_identity
    name: ident
    providerName: aws
    providerSource: hashicorp/aws
    mode: data
    version: latest
```

[contribution process]: https://git.io/JtEzg
