### PR TITLE
#435: Add pre commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,31 @@
+---
+# Build and run the Go binary from the repo
+# REQUIRES: Go v1.16+ installed
+- id: terraform-docs-go
+  name: terraform-docs
+  description: Generate documentation for Terraform modules (via Go binary)
+  language: golang
+  entry: terraform-docs
+  pass_filenames: false
+  types: [terraform]
+
+# Build and run `terraform-docs` assuming it was installed manually
+# or via package manager
+# REQUIRES: terraform-docs to be installed and on the $PATH
+- id: terraform-docs-system
+  name: terraform-docs
+  description: Generate documentation for Terraform modules (via locally-installed CLI)
+  language: system
+  entry: terraform-docs
+  pass_filenames: false
+  types: [terraform]
+
+# Builds and runs the Docker image from the repo
+# REQUIRES: Docker installed
+- id: terraform-docs-docker
+  name: terraform-docs
+  description: Generate documentation for Terraform modules (via Docker build)
+  language: docker
+  entry: terraform-docs
+  pass_filenames: false
+  types: [terraform]

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -123,6 +123,54 @@ jobs:
 Read more about [terraform-docs GitHub Action] and its configuration and
 examples.
 
+## Pre-commit Hook
+
+With [`pre-commit`], you can ensure your Terraform module documentation is kept
+up-to-date each time you make a commit.
+
+First, simply create or update a `.pre-commit-config.yaml`
+in the root of your Git repo with at least the following content:
+
+```yaml
+repos:
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: <VERSION TAG OR SHA TO USE> # For example: "v0.11.2"
+    hooks:
+      - id: terraform-docs-go
+        args: [<ARGS TO PASS INCLUDING PATH>]  # For example: ["--output-file", "README.md", "./mymodule/path"]
+```
+
+(You can also include more than one entry under `hooks:` to update multiple docs.
+Just be sure to adjust the `args:` to pass the path you want terraform-docs to scan.)
+
+Second, install [`pre-commit`] and run `pre-commit` to activate the hooks.
+
+Then, make a Terraform change, `git add` and `git commit`!
+Pre-commit will regenerate your Terraform docs, after which you can
+rerun `git add` and `git commit` to commit the code and doc changes together.
+
+You can also regenerate the docs manually by running `pre-commit -a terraform-docs`.
+
+### Pre-commit via Docker
+
+The pre-commit hook can also be run via Docker, for those who don't have Go installed.
+Just use `id: terraform-docs-docker` in the previous example.
+
+This will build the Docker image from the repo, which can be quite slow.
+To download the pre-built image instead, change your `.pre-commit-config.yaml` to:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: terraform-docs
+        name: terraform-docs
+        language: docker_image
+        entry: quay.io/terraform-docs/terraform-docs:latest  # Or, change latest to pin to a specific version
+        args: [<ARGS TO PASS INCLUDING PATH>]  # For example: ["--output-file", "README.md", "./mymodule/path"]
+        pass_filenames: false
+```
+
 ## Git Hook
 
 A simple git hook (`.git/hooks/pre-commit`) added to your local terraform
@@ -146,5 +194,6 @@ Please refer to it for complete examples and guides.
 [sections]: {{< ref "configuration/#sections" >}}
 [output]: {{< ref "configuration/#output" >}}
 [terraform-docs GitHub Action]: https://github.com/terraform-docs/gh-actions
+[`pre-commit`]: https://pre-commit.com/
 [git hooks]: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
 [pre-commit-terraform]: https://github.com/antonbabenko/pre-commit-terraform


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #435

I did find the [existing instructions](https://terraform-docs.io/user-guide/how-to/#git-hook) on how to use a Git hook, and the references to [antonbabenko/pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform), but I wanted to provide a pre-commit hook here, on this repo, so that users don't require a second repo just to use this tool via pre-commit.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
