### PR TITLE
print cli errors to stderr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -32,7 +33,7 @@ import (
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
 	if err := NewCommand().Execute(); err != nil {
-		fmt.Printf("Error: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This is a small change that prints any errors that surface when
executing the cli (i.e., `cmd.Execute()`) to stderr rather than
stdout.

When redirecting streams, its useful to keep errors separated from
program output so that in the case of an error the message won't be
redirected and is still surfaced. This issue came up for me when
using this terraform-docs in a script, where I encountered an error:

    $ terraform-docs markdown path/not/to/mod > outfile
    zsh: exit 1     terraform-docs markdown path/not/to/mod > outfile

When I ran the above command in my script an error was generated
because the path was incorrect, however the error message wasn't
printed to my console and the outfile was filled with the error
message. The change here modifies the cli's output to instead show:

    $ terraform-docs markdown path/not/to/mod > outfile
    Error: Failed to read module directory: Module directory path/not/to/mod does not exist or cannot be read.
    zsh: exit 1     terraform-docs markdown path/not/to/mod > outfile

and the outfile is empty.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

This change has been tested by compiling and running an executable with the changes. The change to the console output, as shown above, was generated by running the binary which contained the proposed changes.

[contribution process]: https://git.io/JtEzg
