### PR TITLE
Fix missing footer-from if set via CLI flag or config

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -338,8 +338,9 @@ func (c *Config) process() {
 	c.Sections.requirements = c.Sections.visibility("requirements")
 	c.Sections.resources = c.Sections.visibility("resources")
 
-	// Footer section optional and should not cause error with --show-all
-	if c.Sections.ShowAll && c.Sections.footer {
+	// Footer section is optional and should only be enabled if --footer-from
+	// is explicitly set, either via CLI or config file.
+	if c.FooterFrom == "" && !changedfs["footer-from"] {
 		c.Sections.footer = false
 	}
 }
@@ -403,16 +404,16 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	options := terraform.NewOptions()
 
 	// header-from
+	settings.ShowHeader = c.Sections.header
 	options.ShowHeader = settings.ShowHeader
 	options.HeaderFromFile = c.HeaderFrom
 
 	// footer-from
+	settings.ShowFooter = c.Sections.footer
 	options.ShowFooter = settings.ShowFooter
 	options.FooterFromFile = c.FooterFrom
 
 	// sections
-	settings.ShowHeader = c.Sections.header
-	settings.ShowFooter = c.Sections.footer
 	settings.ShowInputs = c.Sections.inputs
 	settings.ShowModuleCalls = c.Sections.modulecalls
 	settings.ShowOutputs = c.Sections.outputs


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This is to fix a small regression where footer-from isn't processed
properly, neither when it's passed via CLI flag nor in a config file.

Fixes #449 

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually compiled and built the binary with the changes and tested for following and made sure the expected output was produced:

- `/bin/terraform-docs md tbl module/`
- `/bin/terraform-docs md tbl --footer-from footer.md module/`
- `/bin/terraform-docs module/` (with `.terraform-docs.yml`: `footer-from: ""`)
- `/bin/terraform-docs module/` (with `.terraform-docs.yml`: `footer-from: "footer.md"`)

[contribution process]: https://git.io/JtEzg
