### PR TITLE
Feat/Issue437/add ability to hide data sources

### DIFF
--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -30,7 +30,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --default                     show Default column or section (default true)
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --output-file string          File in module directory to insert output into (default "")
@@ -40,7 +40,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --output-values-from string   inject output values from file into outputs (default "")
       --required                    show Required column or section (default true)
       --sensitive                   show Sensitive column or section (default true)
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -30,7 +30,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --default                     show Default column or section (default true)
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --output-file string          File in module directory to insert output into (default "")
@@ -40,7 +40,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --output-values-from string   inject output values from file into outputs (default "")
       --required                    show Required column or section (default true)
       --sensitive                   show Sensitive column or section (default true)
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/asciidoc.md
+++ b/docs/reference/asciidoc.md
@@ -34,14 +34,14 @@ terraform-docs asciidoc [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -29,14 +29,14 @@ terraform-docs json [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -31,7 +31,7 @@ terraform-docs markdown document [PATH] [flags]
       --escape                      escape special characters (default true)
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --output-file string          File in module directory to insert output into (default "")
@@ -41,7 +41,7 @@ terraform-docs markdown document [PATH] [flags]
       --output-values-from string   inject output values from file into outputs (default "")
       --required                    show Required column or section (default true)
       --sensitive                   show Sensitive column or section (default true)
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -31,7 +31,7 @@ terraform-docs markdown table [PATH] [flags]
       --escape                      escape special characters (default true)
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --output-file string          File in module directory to insert output into (default "")
@@ -41,7 +41,7 @@ terraform-docs markdown table [PATH] [flags]
       --output-values-from string   inject output values from file into outputs (default "")
       --required                    show Required column or section (default true)
       --sensitive                   show Sensitive column or section (default true)
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -35,14 +35,14 @@ terraform-docs markdown [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/pretty.md
+++ b/docs/reference/pretty.md
@@ -29,14 +29,14 @@ terraform-docs pretty [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")
@@ -109,8 +109,8 @@ generates the following output:
 
     resource.null_resource.foo (resource) (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
     resource.tls_private_key.baz (resource) (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
-    resource.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-    resource.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+    data.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+    data.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
 
 
     input.bool-1 (true)

--- a/docs/reference/terraform-docs.md
+++ b/docs/reference/terraform-docs.md
@@ -23,14 +23,14 @@ terraform-docs [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
   -h, --help                        help for terraform-docs
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/tfvars-hcl.md
+++ b/docs/reference/tfvars-hcl.md
@@ -29,14 +29,14 @@ terraform-docs tfvars hcl [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/tfvars-json.md
+++ b/docs/reference/tfvars-json.md
@@ -28,14 +28,14 @@ terraform-docs tfvars json [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/tfvars.md
+++ b/docs/reference/tfvars.md
@@ -24,14 +24,14 @@ Generate terraform.tfvars of inputs.
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/toml.md
+++ b/docs/reference/toml.md
@@ -28,14 +28,14 @@ terraform-docs toml [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/xml.md
+++ b/docs/reference/xml.md
@@ -28,14 +28,14 @@ terraform-docs xml [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -28,14 +28,14 @@ terraform-docs yaml [PATH] [flags]
   -c, --config string               config file name (default ".terraform-docs.yml")
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide strings                hide section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide strings                hide section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-all                    hide all sections (default false)
       --output-file string          File in module directory to insert output into (default "")
       --output-mode string          Output to file method [inject, replace] (default "inject")
       --output-template string      Output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
-      --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --show strings                show section [data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
       --sort-by string              sort items by criteria [name, required, type] (default "name")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/terraform-docs/plugin-sdk v0.2.0
+	github.com/terraform-docs/plugin-sdk v0.2.1-0.20210329203526-90c9fa0bfae9
 	github.com/terraform-docs/terraform-config-inspect v0.0.0-20210126151735-6ef25af8884f
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	honnef.co/go/tools v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/terraform-docs/plugin-sdk v0.2.0 h1:dOoPRe0TSg42ywdv/DFG6UrCZ2XPwnS/z8uZjEgz7ro=
 github.com/terraform-docs/plugin-sdk v0.2.0/go.mod h1:3G+0nZTeaMF1c5CZh8cOEYeNq0kUL6+DlQOVcxK7eCQ=
+github.com/terraform-docs/plugin-sdk v0.2.1-0.20210329203526-90c9fa0bfae9 h1:S9JjFwxoxMJo99hv5mvBNndN/Hu8DEi8qYPJHzSIk4o=
+github.com/terraform-docs/plugin-sdk v0.2.1-0.20210329203526-90c9fa0bfae9/go.mod h1:3G+0nZTeaMF1c5CZh8cOEYeNq0kUL6+DlQOVcxK7eCQ=
 github.com/terraform-docs/terraform-config-inspect v0.0.0-20210126151735-6ef25af8884f h1:WXgHENMC8JOyj6aRpOlnAnJkZ3ZAkPBOhqYrJ5GOhDE=
 github.com/terraform-docs/terraform-config-inspect v0.0.0-20210126151735-6ef25af8884f/go.mod h1:GtanFwTsRRXScYHOMb5h4K18XQBFeS2tXat9/LrPtPc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	sectionDataSources  = "data-sources"
 	sectionFooter       = "footer"
 	sectionHeader       = "header"
 	sectionInputs       = "inputs"
@@ -30,6 +31,7 @@ const (
 )
 
 var allSections = []string{
+	sectionDataSources,
 	sectionFooter,
 	sectionHeader,
 	sectionInputs,
@@ -49,6 +51,7 @@ type sections struct {
 	ShowAll bool     `yaml:"show-all"`
 	HideAll bool     `yaml:"hide-all"`
 
+	dataSources  bool `yaml:"-"`
 	header       bool `yaml:"-"`
 	footer       bool `yaml:"-"`
 	inputs       bool `yaml:"-"`
@@ -66,6 +69,7 @@ func defaultSections() sections {
 		ShowAll: true,
 		HideAll: false,
 
+		dataSources:  false,
 		header:       false,
 		footer:       false,
 		inputs:       false,
@@ -84,14 +88,14 @@ func (s *sections) validate() error { //nolint:gocyclo
 
 	for _, item := range s.Show {
 		switch item {
-		case allSections[0], allSections[1], allSections[2], allSections[3], allSections[4], allSections[5], allSections[6], allSections[7]:
+		case allSections[0], allSections[1], allSections[2], allSections[3], allSections[4], allSections[5], allSections[6], allSections[7], allSections[8]:
 		default:
 			return fmt.Errorf("'%s' is not a valid section", item)
 		}
 	}
 	for _, item := range s.Hide {
 		switch item {
-		case allSections[0], allSections[1], allSections[2], allSections[3], allSections[4], allSections[5], allSections[6], allSections[7]:
+		case allSections[0], allSections[1], allSections[2], allSections[3], allSections[4], allSections[5], allSections[6], allSections[7], allSections[8]:
 		default:
 			return fmt.Errorf("'%s' is not a valid section", item)
 		}
@@ -359,6 +363,7 @@ func (c *Config) process() {
 		c.Sections.HideAll = true
 	}
 
+	c.Sections.dataSources = c.Sections.visibility("data-sources")
 	c.Sections.header = c.Sections.visibility("header")
 	c.Sections.footer = c.Sections.visibility("footer")
 	c.Sections.inputs = c.Sections.visibility("inputs")
@@ -449,6 +454,7 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	options.FooterFromFile = c.FooterFrom
 
 	// sections
+	settings.ShowDataSources = c.Sections.dataSources
 	settings.ShowInputs = c.Sections.inputs
 	settings.ShowModuleCalls = c.Sections.modulecalls
 	settings.ShowOutputs = c.Sections.outputs

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -85,7 +85,7 @@ func PreRunEFunc(config *Config) func(*cobra.Command, []string) error {
 			return err
 		}
 
-		// set the base moduel directory
+		// set the base module directory
 		config.BaseDir = args[0]
 
 		return nil

--- a/internal/format/asciidoc_document_test.go
+++ b/internal/format/asciidoc_document_test.go
@@ -121,6 +121,10 @@ func TestAsciidocDocument(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/asciidoc_table_test.go
+++ b/internal/format/asciidoc_table_test.go
@@ -121,6 +121,10 @@ func TestAsciidocTable(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/json.go
+++ b/internal/format/json.go
@@ -40,30 +40,7 @@ func (j *JSON) Print(module *terraform.Module, settings *print.Settings) (string
 		Resources:    make([]*terraform.Resource, 0),
 	}
 
-	if settings.ShowHeader {
-		copy.Header = module.Header
-	}
-	if settings.ShowFooter {
-		copy.Footer = module.Footer
-	}
-	if settings.ShowInputs {
-		copy.Inputs = module.Inputs
-	}
-	if settings.ShowModuleCalls {
-		copy.ModuleCalls = module.ModuleCalls
-	}
-	if settings.ShowOutputs {
-		copy.Outputs = module.Outputs
-	}
-	if settings.ShowProviders {
-		copy.Providers = module.Providers
-	}
-	if settings.ShowRequirements {
-		copy.Requirements = module.Requirements
-	}
-	if settings.ShowResources {
-		copy.Resources = module.Resources
-	}
+	print.CopySections(settings, module, copy)
 
 	buffer := new(bytes.Buffer)
 

--- a/internal/format/json_test.go
+++ b/internal/format/json_test.go
@@ -72,6 +72,10 @@ func TestJson(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/markdown_document_test.go
+++ b/internal/format/markdown_document_test.go
@@ -132,6 +132,10 @@ func TestMarkdownDocument(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/markdown_table_test.go
+++ b/internal/format/markdown_table_test.go
@@ -132,6 +132,10 @@ func TestMarkdownTable(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/pretty_test.go
+++ b/internal/format/pretty_test.go
@@ -72,6 +72,10 @@ func TestPretty(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/templates/asciidoc_document.tmpl
+++ b/internal/format/templates/asciidoc_document.tmpl
@@ -48,17 +48,21 @@
     {{ end }}
 {{ end -}}
 
-{{- if .Settings.ShowResources -}}
+{{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
     {{ indent 0 "=" }} Resources
     {{ if not .Module.Resources }}
         No resources.
     {{ else }}
         The following resources are used by this module:
         {{ range .Module.Resources }}
-            {{ if eq (len .URL) 0 }}
-            - {{ .Spec }} {{ printf "(%s)" .GetMode -}}
-            {{- else -}}
-            - {{ .URL }}[{{ .Spec }}] {{ printf "(%s)" .GetMode -}}
+            {{- $isResource := and $.Settings.ShowResources ( eq "resource" (printf "%s" .GetMode)) }}
+            {{- $isDataResource := and $.Settings.ShowDataSources ( eq "data source" (printf "%s" .GetMode)) }}
+            {{- if or $isResource $isDataResource }}
+                {{ if eq (len .URL) 0 }}
+                    - {{ .Spec }} {{ printf "(%s)" .GetMode -}}
+                {{- else -}}
+                    - {{ .URL }}[{{ .Spec }}] {{ printf "(%s)" .GetMode -}}
+                {{- end }}
             {{- end }}
         {{- end }}
     {{ end }}

--- a/internal/format/templates/asciidoc_table.tmpl
+++ b/internal/format/templates/asciidoc_table.tmpl
@@ -50,7 +50,7 @@
     {{ end }}
 {{ end -}}
 
-{{- if .Settings.ShowResources -}}
+{{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
     {{ indent 0 "=" }} Resources
     {{ if not .Module.Resources }}
         No resources.
@@ -59,10 +59,14 @@
         |===
         |Name |Type
         {{- range .Module.Resources }}
-            {{ if eq (len .URL) 0 }}
-                |{{ .Spec }} |{{ .GetMode }}
-            {{- else -}}
-                |{{ .URL }}[{{ .Spec }}] |{{ .GetMode }}
+            {{- $isResource := and $.Settings.ShowResources ( eq "resource" (printf "%s" .GetMode)) }}
+            {{- $isDataResource := and $.Settings.ShowDataSources ( eq "data source" (printf "%s" .GetMode)) }}
+            {{- if or $isResource $isDataResource }}
+                {{ if eq (len .URL) 0 }}
+                    |{{ .Spec }} |{{ .GetMode }}
+                {{- else -}}
+                    |{{ .URL }}[{{ .Spec }}] |{{ .GetMode }}
+                {{- end }}
             {{- end }}
         {{- end }}
         |===

--- a/internal/format/templates/markdown_document.tmpl
+++ b/internal/format/templates/markdown_document.tmpl
@@ -49,17 +49,21 @@
     {{ end }}
 {{ end -}}
 
-{{- if .Settings.ShowResources -}}
+{{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
     {{ indent 0 "#" }} Resources
     {{ if not .Module.Resources }}
         No resources.
     {{ else }}
         The following resources are used by this module:
         {{ range .Module.Resources }}
-            {{ if eq (len .URL) 0 }}
-                - {{ .Spec }} {{ printf "(%s)" .GetMode -}}
-            {{- else -}}
-                - [{{ .Spec }}]({{ .URL }}) {{ printf "(%s)" .GetMode -}}
+            {{- $isResource := and $.Settings.ShowResources ( eq "resource" (printf "%s" .GetMode)) }}
+            {{- $isDataResource := and $.Settings.ShowDataSources ( eq "data source" (printf "%s" .GetMode)) }}
+            {{- if or $isResource $isDataResource }}
+                {{ if eq (len .URL) 0 }}
+                    - {{ .Spec }} {{ printf "(%s)" .GetMode -}}
+                {{- else -}}
+                    - [{{ .Spec }}]({{ .URL }}) {{ printf "(%s)" .GetMode -}}
+                {{- end }}
             {{- end }}
         {{- end }}
     {{ end }}

--- a/internal/format/templates/markdown_table.tmpl
+++ b/internal/format/templates/markdown_table.tmpl
@@ -44,7 +44,7 @@
     {{ end }}
 {{ end -}}
 
-{{- if .Settings.ShowResources -}}
+{{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
     {{ indent 0 "#" }} Resources
     {{ if not .Module.Resources }}
         No resources.
@@ -52,10 +52,14 @@
         | Name | Type |
         |------|------|
         {{- range .Module.Resources }}
-            {{ if eq (len .URL) 0 }}
-                | {{ .Spec }} | {{ .GetMode }} |
-            {{- else -}}
-                | [{{ .Spec }}]({{ .URL }}) | {{ .GetMode }} |
+            {{- $isResource := and $.Settings.ShowResources ( eq "resource" (printf "%s" .GetMode)) }}
+            {{- $isDataResource := and $.Settings.ShowDataSources ( eq "data source" (printf "%s" .GetMode)) }}
+            {{- if or $isResource $isDataResource }}
+                {{ if eq (len .URL) 0 }}
+                    | {{ .Spec }} | {{ .GetMode }} |
+                {{- else -}}
+                    | [{{ .Spec }}]({{ .URL }}) | {{ .GetMode }} |
+                {{- end }}
             {{- end }}
         {{- end }}
     {{ end }}

--- a/internal/format/templates/pretty.tmpl
+++ b/internal/format/templates/pretty.tmpl
@@ -30,19 +30,25 @@
         {{- range . }}
             {{- printf "module.%s" .Name | colorize "\033[36m" }}{{ printf " (%s)" .FullName }}
         {{ end -}}
-        {{- printf "\n\n" -}}
-    {{ end -}}
-{{ end -}}
-
-{{- if .Settings.ShowResources -}}
-    {{- with .Module.Resources }}
-        {{- range . }}
-            {{- $url := ternary .URL (printf " (%s)" .URL) "" }}
-            {{- printf "resource.%s (%s)" .Spec .GetMode | colorize "\033[36m" }}{{ $url }}
-        {{ end -}}
     {{ end -}}
     {{- printf "\n\n" -}}
 {{ end -}}
+
+{{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
+    {{- with .Module.Resources }}
+        {{- range . }}
+            {{- $isResource := and $.Settings.ShowResources ( eq "resource" (printf "%s" .GetMode)) }}
+            {{- $isDataResource := and $.Settings.ShowDataSources ( eq "data source" (printf "%s" .GetMode)) }}
+            {{- $url := ternary .URL (printf " (%s)" .URL) "" }}
+            {{- if $isResource }}
+                {{- printf "resource.%s (%s)" .Spec .GetMode | colorize "\033[36m" }}{{ $url }}
+            {{ end -}}
+            {{- if $isDataResource }}
+                {{- printf "data.%s (%s)" .Spec .GetMode | colorize "\033[36m" }}{{ $url }}
+            {{ end -}}
+        {{- end }}
+    {{ end }}
+{{ end }}
 
 {{- if .Settings.ShowInputs -}}
     {{- with .Module.Inputs }}

--- a/internal/format/testdata/asciidoc/document-OnlyDataSources.golden
+++ b/internal/format/testdata/asciidoc/document-OnlyDataSources.golden
@@ -1,0 +1,6 @@
+== Resources
+
+The following resources are used by this module:
+
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)

--- a/internal/format/testdata/asciidoc/document-OnlyResources.golden
+++ b/internal/format/testdata/asciidoc/document-OnlyResources.golden
@@ -4,5 +4,3 @@ The following resources are used by this module:
 
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] (resource)
 - https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] (resource)
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] (data source)
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] (data source)

--- a/internal/format/testdata/asciidoc/table-OnlyDataSources.golden
+++ b/internal/format/testdata/asciidoc/table-OnlyDataSources.golden
@@ -1,0 +1,8 @@
+== Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
+|===

--- a/internal/format/testdata/asciidoc/table-OnlyResources.golden
+++ b/internal/format/testdata/asciidoc/table-OnlyResources.golden
@@ -5,6 +5,4 @@
 |Name |Type
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.foo] |resource
 |https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.baz] |resource
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.current] |data source
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity[aws_caller_identity.ident] |data source
 |===

--- a/internal/format/testdata/json/json-OnlyDataSources.golden
+++ b/internal/format/testdata/json/json-OnlyDataSources.golden
@@ -1,0 +1,27 @@
+{
+  "header": "",
+  "footer": "",
+  "inputs": [],
+  "modules": [],
+  "outputs": [],
+  "providers": [],
+  "requirements": [],
+  "resources": [
+    {
+      "type": "caller_identity",
+      "name": "current",
+      "provider": "aws",
+      "source": "hashicorp/aws",
+      "mode": "data",
+      "version": "latest"
+    },
+    {
+      "type": "caller_identity",
+      "name": "ident",
+      "provider": "aws",
+      "source": "hashicorp/aws",
+      "mode": "data",
+      "version": "latest"
+    }
+  ]
+}

--- a/internal/format/testdata/json/json-OnlyResources.golden
+++ b/internal/format/testdata/json/json-OnlyResources.golden
@@ -22,22 +22,6 @@
       "source": "hashicorp/tls",
       "mode": "managed",
       "version": "latest"
-    },
-    {
-      "type": "caller_identity",
-      "name": "current",
-      "provider": "aws",
-      "source": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
-    },
-    {
-      "type": "caller_identity",
-      "name": "ident",
-      "provider": "aws",
-      "source": "hashicorp/aws",
-      "mode": "data",
-      "version": "latest"
     }
   ]
 }

--- a/internal/format/testdata/markdown/document-OnlyDataSources.golden
+++ b/internal/format/testdata/markdown/document-OnlyDataSources.golden
@@ -1,0 +1,6 @@
+## Resources
+
+The following resources are used by this module:
+
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)

--- a/internal/format/testdata/markdown/document-OnlyResources.golden
+++ b/internal/format/testdata/markdown/document-OnlyResources.golden
@@ -4,5 +4,3 @@ The following resources are used by this module:
 
 - [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
 - [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
-- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
-- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)

--- a/internal/format/testdata/markdown/table-OnlyDataSources.golden
+++ b/internal/format/testdata/markdown/table-OnlyDataSources.golden
@@ -1,0 +1,6 @@
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/internal/format/testdata/markdown/table-OnlyResources.golden
+++ b/internal/format/testdata/markdown/table-OnlyResources.golden
@@ -4,5 +4,3 @@
 |------|------|
 | [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/internal/format/testdata/pretty/pretty-Base.golden
+++ b/internal/format/testdata/pretty/pretty-Base.golden
@@ -55,8 +55,8 @@ module.baz (baz,4.5.6)
 
 resource.null_resource.foo (resource) (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
 resource.tls_private_key.baz (resource) (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
-resource.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-resource.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+data.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+data.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
 
 
 input.unquoted (required)

--- a/internal/format/testdata/pretty/pretty-OnlyDataSources.golden
+++ b/internal/format/testdata/pretty/pretty-OnlyDataSources.golden
@@ -1,0 +1,2 @@
+data.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+data.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)

--- a/internal/format/testdata/pretty/pretty-OnlyResources.golden
+++ b/internal/format/testdata/pretty/pretty-OnlyResources.golden
@@ -1,4 +1,2 @@
 resource.null_resource.foo (resource) (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
 resource.tls_private_key.baz (resource) (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
-resource.aws_caller_identity.current (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-resource.aws_caller_identity.ident (data source) (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)

--- a/internal/format/testdata/pretty/pretty-WithColor.golden
+++ b/internal/format/testdata/pretty/pretty-WithColor.golden
@@ -55,8 +55,8 @@ followed by another line of text.
 
 [36mresource.null_resource.foo (resource)[0m (https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)
 [36mresource.tls_private_key.baz (resource)[0m (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
-[36mresource.aws_caller_identity.current (data source)[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
-[36mresource.aws_caller_identity.ident (data source)[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+[36mdata.aws_caller_identity.current (data source)[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
+[36mdata.aws_caller_identity.ident (data source)[0m (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)
 
 
 [36minput.unquoted[0m (required)

--- a/internal/format/testdata/toml/toml-OnlyDataSources.golden
+++ b/internal/format/testdata/toml/toml-OnlyDataSources.golden
@@ -1,0 +1,23 @@
+header = ""
+footer = ""
+inputs = []
+modules = []
+outputs = []
+providers = []
+requirements = []
+
+[[resources]]
+  type = "caller_identity"
+  name = "current"
+  provider = "aws"
+  source = "hashicorp/aws"
+  mode = "data"
+  version = "latest"
+
+[[resources]]
+  type = "caller_identity"
+  name = "ident"
+  provider = "aws"
+  source = "hashicorp/aws"
+  mode = "data"
+  version = "latest"

--- a/internal/format/testdata/toml/toml-OnlyResources.golden
+++ b/internal/format/testdata/toml/toml-OnlyResources.golden
@@ -21,19 +21,3 @@ requirements = []
   source = "hashicorp/tls"
   mode = "managed"
   version = "latest"
-
-[[resources]]
-  type = "caller_identity"
-  name = "current"
-  provider = "aws"
-  source = "hashicorp/aws"
-  mode = "data"
-  version = "latest"
-
-[[resources]]
-  type = "caller_identity"
-  name = "ident"
-  provider = "aws"
-  source = "hashicorp/aws"
-  mode = "data"
-  version = "latest"

--- a/internal/format/testdata/xml/xml-OnlyDataSources.golden
+++ b/internal/format/testdata/xml/xml-OnlyDataSources.golden
@@ -8,19 +8,19 @@
   <requirements></requirements>
   <resources>
     <resource>
-      <type>resource</type>
-      <name>foo</name>
-      <provider>null</provider>
-      <source>hashicorp/null</source>
-      <mode>managed</mode>
+      <type>caller_identity</type>
+      <name>current</name>
+      <provider>aws</provider>
+      <source>hashicorp/aws</source>
+      <mode>data</mode>
       <version>latest</version>
     </resource>
     <resource>
-      <type>private_key</type>
-      <name>baz</name>
-      <provider>tls</provider>
-      <source>hashicorp/tls</source>
-      <mode>managed</mode>
+      <type>caller_identity</type>
+      <name>ident</name>
+      <provider>aws</provider>
+      <source>hashicorp/aws</source>
+      <mode>data</mode>
       <version>latest</version>
     </resource>
   </resources>

--- a/internal/format/testdata/yaml/yaml-OnlyDataSources.golden
+++ b/internal/format/testdata/yaml/yaml-OnlyDataSources.golden
@@ -1,0 +1,20 @@
+header: ""
+footer: ""
+inputs: []
+modules: []
+outputs: []
+providers: []
+requirements: []
+resources:
+  - type: caller_identity
+    name: current
+    provider: aws
+    source: hashicorp/aws
+    mode: data
+    version: latest
+  - type: caller_identity
+    name: ident
+    provider: aws
+    source: hashicorp/aws
+    mode: data
+    version: latest

--- a/internal/format/testdata/yaml/yaml-OnlyResources.golden
+++ b/internal/format/testdata/yaml/yaml-OnlyResources.golden
@@ -18,15 +18,3 @@ resources:
     source: hashicorp/tls
     mode: managed
     version: latest
-  - type: caller_identity
-    name: current
-    provider: aws
-    source: hashicorp/aws
-    mode: data
-    version: latest
-  - type: caller_identity
-    name: ident
-    provider: aws
-    source: hashicorp/aws
-    mode: data
-    version: latest

--- a/internal/format/toml.go
+++ b/internal/format/toml.go
@@ -30,41 +30,18 @@ func NewTOML(settings *print.Settings) print.Engine {
 
 // Print a Terraform module as toml.
 func (t *TOML) Print(module *terraform.Module, settings *print.Settings) (string, error) {
-	copy := terraform.Module{
+	copy := &terraform.Module{
 		Header:       "",
 		Footer:       "",
-		Providers:    make([]*terraform.Provider, 0),
 		Inputs:       make([]*terraform.Input, 0),
 		ModuleCalls:  make([]*terraform.ModuleCall, 0),
 		Outputs:      make([]*terraform.Output, 0),
+		Providers:    make([]*terraform.Provider, 0),
 		Requirements: make([]*terraform.Requirement, 0),
 		Resources:    make([]*terraform.Resource, 0),
 	}
 
-	if settings.ShowHeader {
-		copy.Header = module.Header
-	}
-	if settings.ShowFooter {
-		copy.Footer = module.Footer
-	}
-	if settings.ShowInputs {
-		copy.Inputs = module.Inputs
-	}
-	if settings.ShowModuleCalls {
-		copy.ModuleCalls = module.ModuleCalls
-	}
-	if settings.ShowOutputs {
-		copy.Outputs = module.Outputs
-	}
-	if settings.ShowProviders {
-		copy.Providers = module.Providers
-	}
-	if settings.ShowRequirements {
-		copy.Requirements = module.Requirements
-	}
-	if settings.ShowResources {
-		copy.Resources = module.Resources
-	}
+	print.CopySections(settings, module, copy)
 
 	buffer := new(bytes.Buffer)
 	encoder := toml.NewEncoder(buffer)

--- a/internal/format/toml_test.go
+++ b/internal/format/toml_test.go
@@ -61,6 +61,10 @@ func TestToml(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/xml.go
+++ b/internal/format/xml.go
@@ -39,30 +39,7 @@ func (x *XML) Print(module *terraform.Module, settings *print.Settings) (string,
 		Resources:    make([]*terraform.Resource, 0),
 	}
 
-	if settings.ShowHeader {
-		copy.Header = module.Header
-	}
-	if settings.ShowFooter {
-		copy.Footer = module.Footer
-	}
-	if settings.ShowInputs {
-		copy.Inputs = module.Inputs
-	}
-	if settings.ShowModuleCalls {
-		copy.ModuleCalls = module.ModuleCalls
-	}
-	if settings.ShowOutputs {
-		copy.Outputs = module.Outputs
-	}
-	if settings.ShowProviders {
-		copy.Providers = module.Providers
-	}
-	if settings.ShowRequirements {
-		copy.Requirements = module.Requirements
-	}
-	if settings.ShowResources {
-		copy.Resources = module.Resources
-	}
+	print.CopySections(settings, module, copy)
 
 	out, err := xml.MarshalIndent(copy, "", "  ")
 	if err != nil {

--- a/internal/format/xml_test.go
+++ b/internal/format/xml_test.go
@@ -61,6 +61,10 @@ func TestXml(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/format/yaml.go
+++ b/internal/format/yaml.go
@@ -41,30 +41,7 @@ func (y *YAML) Print(module *terraform.Module, settings *print.Settings) (string
 		Resources:    make([]*terraform.Resource, 0),
 	}
 
-	if settings.ShowHeader {
-		copy.Header = module.Header
-	}
-	if settings.ShowFooter {
-		copy.Footer = module.Footer
-	}
-	if settings.ShowInputs {
-		copy.Inputs = module.Inputs
-	}
-	if settings.ShowModuleCalls {
-		copy.ModuleCalls = module.ModuleCalls
-	}
-	if settings.ShowOutputs {
-		copy.Outputs = module.Outputs
-	}
-	if settings.ShowProviders {
-		copy.Providers = module.Providers
-	}
-	if settings.ShowRequirements {
-		copy.Requirements = module.Requirements
-	}
-	if settings.ShowResources {
-		copy.Resources = module.Resources
-	}
+	print.CopySections(settings, module, copy)
 
 	buffer := new(bytes.Buffer)
 

--- a/internal/format/yaml_test.go
+++ b/internal/format/yaml_test.go
@@ -61,6 +61,10 @@ func TestYaml(t *testing.T) {
 		},
 
 		// Only section
+		"OnlyDataSources": {
+			settings: print.Settings{ShowDataSources: true},
+			options:  terraform.Options{},
+		},
 		"OnlyHeader": {
 			settings: print.Settings{ShowHeader: true},
 			options:  terraform.Options{},

--- a/internal/testutil/settings.go
+++ b/internal/testutil/settings.go
@@ -19,6 +19,7 @@ import (
 // WithSections appends show all sections to provided Settings.
 func WithSections(override ...print.Settings) print.Settings {
 	base := print.Settings{
+		ShowDataSources:  true,
 		ShowFooter:       true,
 		ShowHeader:       true,
 		ShowInputs:       true,


### PR DESCRIPTION
### Description of your changes

With this PR we add the ability to hide data-sources from the resources section

I've implemented using the target that data-sources is a resource, thinking that to the Terraform, resources are managed or data.

depends: https://github.com/terraform-docs/plugin-sdk/pull/23 to update the go.mod file

fix: #437

### How has this code been tested

e.g.:

---
The:
`terraform-docs markdown table --hide-all --show=resources --show=data-sources .`

Will generate:

## Resources

| Name | Type |
|------|------|
| [aws_lambda_function.index](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
---

Or the
`terraform-docs markdown table --hide-all --show=resources .`

Will generate:

## Resources

| Name | Type |
|------|------|
| [aws_lambda_function.index](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
---

Or the
`terraform-docs markdown table --hide-all --show=data-sources .`

Will generate:

## Resources

| Name | Type |
|------|------|
| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
---

<!-- Fixes #437 -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

[contribution process]: https://git.io/JtEzg
