### PR TITLE
Feature/lssue461/add description flag

### DIFF
--- a/cmd/tfvars/hcl/hcl.go
+++ b/cmd/tfvars/hcl/hcl.go
@@ -26,5 +26,6 @@ func NewCommand(config *cli.Config) *cobra.Command {
 		PreRunE:     cli.PreRunEFunc(config),
 		RunE:        cli.RunEFunc(config),
 	}
+	cmd.PersistentFlags().BoolVar(&config.Settings.Description, "description", false, "show Descriptions on variables")
 	return cmd
 }

--- a/docs/reference/tfvars-hcl.md
+++ b/docs/reference/tfvars-hcl.md
@@ -19,7 +19,8 @@ terraform-docs tfvars hcl [PATH] [flags]
 ## Options
 
 ```console
-  -h, --help   help for hcl
+      --description   show Descriptions on variables
+  -h, --help          help for hcl
 ```
 
 ## Inherited Options

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -262,26 +262,28 @@ func (s *sort) validate() error {
 }
 
 type settings struct {
-	Anchor    bool `yaml:"anchor"`
-	Color     bool `yaml:"color"`
-	Default   bool `yaml:"default"`
-	Escape    bool `yaml:"escape"`
-	Indent    int  `yaml:"indent"`
-	Required  bool `yaml:"required"`
-	Sensitive bool `yaml:"sensitive"`
-	Type      bool `yaml:"type"`
+	Anchor      bool `yaml:"anchor"`
+	Color       bool `yaml:"color"`
+	Default     bool `yaml:"default"`
+	Escape      bool `yaml:"escape"`
+	Indent      int  `yaml:"indent"`
+	Required    bool `yaml:"required"`
+	Sensitive   bool `yaml:"sensitive"`
+	Type        bool `yaml:"type"`
+	Description bool `yaml:"description"`
 }
 
 func defaultSettings() settings {
 	return settings{
-		Anchor:    true,
-		Color:     true,
-		Default:   true,
-		Escape:    true,
-		Indent:    2,
-		Required:  true,
-		Sensitive: true,
-		Type:      true,
+		Anchor:      true,
+		Color:       true,
+		Default:     true,
+		Escape:      true,
+		Indent:      2,
+		Required:    true,
+		Sensitive:   true,
+		Type:        true,
+		Description: false,
 	}
 }
 
@@ -435,6 +437,7 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	settings.EscapeCharacters = c.Settings.Escape
 	settings.IndentLevel = c.Settings.Indent
 	settings.ShowAnchor = c.Settings.Anchor
+	settings.ShowDescription = c.Settings.Description
 	settings.ShowColor = c.Settings.Color
 	settings.ShowDefault = c.Settings.Default
 	settings.ShowRequired = c.Settings.Required

--- a/internal/format/templates/tfvars_hcl.tmpl
+++ b/internal/format/templates/tfvars_hcl.tmpl
@@ -1,5 +1,11 @@
 {{- if .Module.Inputs -}}
     {{- range $i, $k := .Module.Inputs -}}
+      {{ if and $k.Description showDescription -}} 
+          {{ convertToComment $k.Description }}
+          {{ align $k.Name $i }} = {{ value $k.GetValue }}
+
+      {{ else -}}
         {{ align $k.Name $i }} = {{ value $k.GetValue }}
+      {{ end -}}
     {{ end -}}
 {{- end -}}

--- a/internal/format/testdata/tfvars/hcl-PrintDescription.golden
+++ b/internal/format/testdata/tfvars/hcl-PrintDescription.golden
@@ -1,0 +1,104 @@
+
+# A variable with underscores.
+input_with_underscores = ""
+
+# It's list number two.
+list-2 = ""
+
+# It's map number two.
+map-2 = ""
+
+# It's number number two.
+number-2 = ""
+
+# It's string number two.
+string-2 = ""
+
+string_no_default = ""
+unquoted          = ""
+
+# It's bool number one.
+bool-1 = true
+
+# It's bool number two.
+bool-2 = false
+
+bool-3             = true
+bool_default_false = false
+
+# This is a complicated one. We need a newline.  
+# And an example in a code block
+# ```
+# default     = [
+#   "machine rack01:neptune"
+# ]
+# ```
+#
+input-with-code-block = [
+  "name rack:location"
+]
+
+# It includes v1 | v2 | v3
+input-with-pipe = "v1"
+
+# It's list number one.
+list-1 = [
+  "a",
+  "b",
+  "c"
+]
+
+list-3             = []
+list_default_empty = []
+
+# This description is itself markdown.
+#
+# It spans over multiple lines.
+#
+long_type = {
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+
+# It's map number one.
+map-1 = {
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+
+map-3 = {}
+
+# The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+no-escape-default-value = "VALUE_WITH_UNDERSCORE"
+
+# It's number number one.
+number-1 = 42
+
+number-3             = "19"
+number-4             = 15.75
+number_default_zero  = 0
+object_default_empty = {}
+
+# It's string number one.
+string-1 = "bar"
+
+string-3             = ""
+string-special-chars = "\\.<>[]{}_-"
+string_default_empty = ""
+string_default_null  = ""
+
+# The description contains url. https://www.domain.com/foo/bar_baz.html
+with-url = ""

--- a/internal/format/tfvars_hcl_test.go
+++ b/internal/format/tfvars_hcl_test.go
@@ -42,6 +42,19 @@ func TestTfvarsHcl(t *testing.T) {
 			settings: print.Settings{EscapeCharacters: true},
 			options:  terraform.Options{},
 		},
+		"PrintDescription": {
+			settings: testutil.WithSections(
+				print.Settings{
+					ShowDescription: true,
+				},
+			),
+			options: terraform.Options{
+				SortBy: &terraform.SortBy{
+					Name:     true,
+					Required: true,
+				},
+			},
+		},
 		"SortByName": {
 			settings: testutil.WithSections(),
 			options: terraform.Options{

--- a/internal/print/settings.go
+++ b/internal/print/settings.go
@@ -46,6 +46,12 @@ type Settings struct {
 	// scope: Pretty
 	ShowColor bool
 
+	// ShowDescription show "Descriptions on variables" column
+	//
+	// default: false
+	// scope: tfvars hcl
+	ShowDescription bool
+
 	// ShowDefault show "Default" column
 	//
 	// default: true
@@ -128,6 +134,7 @@ func DefaultSettings() *Settings {
 		ShowAnchor:       true,
 		ShowColor:        true,
 		ShowDefault:      true,
+		ShowDescription:  false,
 		ShowFooter:       false,
 		ShowHeader:       true,
 		ShowInputs:       true,


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
- Add `--description` boolean flag that only works when `tfvars hcl` command.
 

feature #461 
<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
- Add New Test Pattern  for `trvars hcl` command as `internal/format/testdata/tfvars/hcl-PrintDescription.golden`

[contribution process]: https://git.io/JtEzg
