### PR TITLE
Deprecate '--sort-by-XX' in favor of '--sort-by XX'

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,8 +68,14 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&config.Output.Template, "output-template", cli.OutputTemplate, "Output template")
 
 	cmd.PersistentFlags().BoolVar(&config.Sort.Enabled, "sort", true, "sort items")
-	cmd.PersistentFlags().BoolVar(&config.Sort.By.Required, "sort-by-required", false, "sort items by name and print required ones first (default false)")
-	cmd.PersistentFlags().BoolVar(&config.Sort.By.Type, "sort-by-type", false, "sort items by type of them (default false)")
+	cmd.PersistentFlags().StringVar(&config.Sort.By, "sort-by", "name", "sort items by criteria ["+cli.SortTypes+"]")
+
+	// deprecated flags ==>
+	cmd.PersistentFlags().BoolVar(&config.Sort.Criteria.Required, "sort-by-required", false, "sort items by name and print required ones first (default false)")
+	cmd.PersistentFlags().BoolVar(&config.Sort.Criteria.Type, "sort-by-type", false, "sort items by type of them (default false)")
+	cmd.PersistentFlags().MarkDeprecated("sort-by-required", "use '--sort-by required' instead") //nolint:errcheck,gosec
+	cmd.PersistentFlags().MarkDeprecated("sort-by-type", "use '--sort-by type' instead")         //nolint:errcheck,gosec
+	// <==
 
 	cmd.PersistentFlags().StringVar(&config.HeaderFrom, "header-from", "main.tf", "relative path of a file to read header from")
 	cmd.PersistentFlags().StringVar(&config.FooterFrom, "footer-from", "", "relative path of a file to read footer from (default \"\")")

--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -43,8 +43,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
       --type                        show Type column or section (default true)
 ```
 

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -43,8 +43,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
       --type                        show Type column or section (default true)
 ```
 

--- a/docs/reference/asciidoc.md
+++ b/docs/reference/asciidoc.md
@@ -44,8 +44,7 @@ terraform-docs asciidoc [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Subcommands

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -39,8 +39,7 @@ terraform-docs json [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Example

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -44,8 +44,7 @@ terraform-docs markdown document [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
       --type                        show Type column or section (default true)
 ```
 

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -44,8 +44,7 @@ terraform-docs markdown table [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
       --type                        show Type column or section (default true)
 ```
 

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -45,8 +45,7 @@ terraform-docs markdown [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Subcommands

--- a/docs/reference/pretty.md
+++ b/docs/reference/pretty.md
@@ -39,8 +39,7 @@ terraform-docs pretty [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Example

--- a/docs/reference/terraform-docs.md
+++ b/docs/reference/terraform-docs.md
@@ -33,8 +33,7 @@ terraform-docs [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Subcommands

--- a/docs/reference/tfvars-hcl.md
+++ b/docs/reference/tfvars-hcl.md
@@ -38,8 +38,7 @@ terraform-docs tfvars hcl [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Example

--- a/docs/reference/tfvars-json.md
+++ b/docs/reference/tfvars-json.md
@@ -38,8 +38,7 @@ terraform-docs tfvars json [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Example

--- a/docs/reference/tfvars.md
+++ b/docs/reference/tfvars.md
@@ -34,8 +34,7 @@ Generate terraform.tfvars of inputs.
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Subcommands

--- a/docs/reference/toml.md
+++ b/docs/reference/toml.md
@@ -38,8 +38,7 @@ terraform-docs toml [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Example

--- a/docs/reference/xml.md
+++ b/docs/reference/xml.md
@@ -38,8 +38,7 @@ terraform-docs xml [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Example

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -38,8 +38,7 @@ terraform-docs yaml [PATH] [flags]
       --show strings                show section [footer, header, inputs, modules, outputs, providers, requirements, resources]
       --show-all                    show all sections (default true)
       --sort                        sort items (default true)
-      --sort-by-required            sort items by name and print required ones first (default false)
-      --sort-by-type                sort items by type of them (default false)
+      --sort-by string              sort items by criteria [name, required, type] (default "name")
 ```
 
 ## Example

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -68,9 +68,7 @@ output-values:
 
 sort:
   enabled: true
-  by:
-    - required
-    - type
+  by: name
 
 settings:
   anchor: true
@@ -89,7 +87,6 @@ settings:
 - `sections.hide-all` and `sections.show-all`
 - `sections.hide-all` and `sections.hide`
 - `sections.show-all` and `sections.show`
-- `sort.by.required` and `sort.by.type`
 
 ## Formatters
 
@@ -199,3 +196,14 @@ output:
     
     {{ .Content }}
 ```
+
+## Sort
+
+To enable sorting of elements `sort.enabled` (or `--sort bool` CLI flag) can be
+used. This will indicate sorting is enabled or not, but consecutively type of
+sorting can also be specified with `sort.by` (or `--sort-by string` CLI flag).
+The following sort types are supported:
+
+- `name` (default): name of items
+- `required`: by name of inputs AND show required ones first
+- `type`: type of inputs

--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -27,8 +27,7 @@ sections:
 
 sort:
   enabled: true
-  by:
-    - required
+  by: required
 
 settings:
   indent: 4

--- a/internal/cli/reader_test.go
+++ b/internal/cli/reader_test.go
@@ -318,62 +318,6 @@ func TestOverrideHide(t *testing.T) {
 	}
 }
 
-func TestUpdateSortTypes(t *testing.T) {
-	tests := []struct {
-		name       string
-		appendFn   func(config *Config)
-		expectedFn func(config *Config) bool
-		wantErr    bool
-		errMsg     string
-	}{
-		{
-			name:       "override values of given field",
-			appendFn:   func(config *Config) { config.Sort.ByList = append(config.Sort.ByList, "required") },
-			expectedFn: func(config *Config) bool { return config.Sort.By.Required },
-			wantErr:    false,
-			errMsg:     "",
-		},
-		{
-			name:       "override values of given field",
-			appendFn:   func(config *Config) { config.Sort.ByList = append(config.Sort.ByList, "type") },
-			expectedFn: func(config *Config) bool { return config.Sort.By.Type },
-			wantErr:    false,
-			errMsg:     "",
-		},
-		{
-			name:       "override values of given field",
-			appendFn:   func(config *Config) { config.Sort.ByList = append(config.Sort.ByList, "unknown") },
-			expectedFn: func(config *Config) bool { return false },
-			wantErr:    true,
-			errMsg:     "field with tag: 'name', value; 'unknown' not found or not readable",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
-			config := DefaultConfig()
-			c := cfgreader{config: config}
-
-			tt.appendFn(config)
-
-			// make sure before values is false
-			assert.Equal(false, tt.expectedFn(config))
-
-			// then update sort types
-			err := c.updateSortTypes()
-
-			if tt.wantErr {
-				assert.NotNil(err)
-				assert.Equal(tt.errMsg, err.Error())
-			} else {
-				// then make sure values is true
-				assert.Nil(err)
-				assert.Equal(true, tt.expectedFn(config))
-			}
-		})
-	}
-}
-
 func TestFindField(t *testing.T) {
 	type sample struct {
 		A string `foo:"a"`


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This deprecates sort by flags in favor of their corresponding dynamic
valued ones. Affected flags are:

- `--sort-by-required`
- `--sort-by-type`

In return new `--sort-by string` is added with following values:

- `name` (default)
- `required`
- `type`

Note that the behavior of `--sort bool` was not changed and to disable
sorting altogether you can run `--sort false`.

Fixes #448

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

No extra test is needed, just make sure the current ones pass.

[contribution process]: https://git.io/JtEzg
