### PR TITLE
Support inline comments variation for Markdown and AsciiDoc

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -197,6 +197,40 @@ output:
     {{ .Content }}
 ```
 
+### Template Comment
+
+Markdown doesn't officially support inline commenting, there are multiple ways
+to do it as a workaround, though. The following formats are supported as begin
+and end comments of a template:
+
+- `<!-- This is a comment -->`
+- `[]: # (This is a comment)`
+- `[]: # "This is a comment"`
+- `[]: # 'This is a comment'`
+- `[//]: # (This is a comment)`
+- `[comment]: # (This is a comment)`
+
+The following is also supported for AsciiDoc format:
+
+- `// This is a comment`
+
+The following can be used where HTML comments are not supported (e.g. Bitbucket
+Cloud):
+
+```yaml
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    [//]: # (BEGIN_TF_DOCS)    
+    {{ .Content }}
+
+    [//]: # (END_TF_DOCS)
+```
+
+Note: The empty line before `[//]: # (END_TF_DOCS)` is mandatory in order for
+Markdown engine to properly process the comment line after the paragraph.
+
 ## Sort
 
 To enable sorting of elements `sort.enabled` (or `--sort bool` CLI flag) can be

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -199,17 +199,43 @@ func (o *output) validate() error { //nolint:gocyclo
 			return fmt.Errorf("value of '--output-template' should contain at least 3 lines (begin comment, {{ .Content }}, and end comment)")
 		}
 
-		if !strings.Contains(lines[0], "<!--") || !strings.Contains(lines[0], "-->") {
+		if !isInlineComment(lines[0]) {
 			return fmt.Errorf("value of '--output-template' is missing begin comment")
 		}
 		o.BeginComment = strings.TrimSpace(lines[0])
 
-		if !strings.Contains(lines[len(lines)-1], "<!--") || !strings.Contains(lines[len(lines)-1], "-->") {
+		if !isInlineComment(lines[len(lines)-1]) {
 			return fmt.Errorf("value of '--output-template' is missing end comment")
 		}
 		o.EndComment = strings.TrimSpace(lines[len(lines)-1])
 	}
 	return nil
+}
+
+// Detect if a particular line is a Markdown comment
+//
+// ref: https://www.jamestharpe.com/markdown-comments/
+func isInlineComment(line string) bool {
+	switch {
+	// Markdown specific
+	case strings.HasPrefix(line, "<!--") && strings.HasSuffix(line, "-->"):
+		return true
+	case strings.HasPrefix(line, "[]: # ("):
+		return true
+	case strings.HasPrefix(line, "[]: # \""):
+		return true
+	case strings.HasPrefix(line, "[]: # '"):
+		return true
+	case strings.HasPrefix(line, "[//]: # ("):
+		return true
+	case strings.HasPrefix(line, "[comment]: # ("):
+		return true
+
+	// AsciiDoc specific
+	case strings.HasPrefix(line, "//"):
+		return true
+	}
+	return false
 }
 
 type outputvalues struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Some of the Markdown engines (e.g. Bitbucket Cloud) are not able to
process HTML comment but as a workaround they support variation of
inline comments as follow:

- `<!-- This is a comment -->`
- `[]: # (This is a comment)`
- `[]: # "This is a comment"`
- `[]: # 'This is a comment'`
- `[//]: # (This is a comment)`
- `[comment]: # (This is a comment)`

The following is also supported for AsciiDoc format:

- `// This is a comment`

Fixes #463

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually tested with multiple comment examples provided above.

[contribution process]: https://git.io/JtEzg
