### PR TITLE
Version constraints configuration

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -43,6 +43,8 @@ Below is a complete list of options that you can use with `terraform-docs`, with
 corresponding default values (if applicable).
 
 ```yaml
+version: ""
+
 formatter: <FORMATTER_NAME>
 
 header-from: main.tf
@@ -91,6 +93,29 @@ settings:
 
 **Note:** As of `v0.13.0`, `sections.hide-all` and `settings.show-all` are deprecated
 and removed in favor of explicit use of `settings.hide` and `settings.show`.
+
+## Version
+
+Since `v0.13.0`
+
+terraform-docs version constraints is almost identical to the syntax used by
+Terraform. A version constraint is a string literal containing one or more condition,
+which are separated by commas.
+
+```yaml
+version: ">= 0.13.0, < 1.0.0"
+```
+
+Each condition consists of an operator and a version number. A version number is
+a series of numbers separated by dots (e.g. `0.13.0`). Note that version number
+should not have leading `v` in it.
+
+Valid operators are as follow:
+
+- `=` (or no operator): allows for exact version number.
+- `!=`: exclude an exact version number.
+- `>`, `>=`, `<`, and `<=`: comparisons against a specific version.
+- `~>`: only the rightmost version component to increment.
 
 ## Formatters
 

--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -1,4 +1,9 @@
+# # terraform-docs version constraints for execution
+# # more information: https://terraform-docs.io/user-guide/configuration/#version
+# version: ">= 0.10, < 0.12"
+
 formatter: markdown table
+
 header-from: doc.txt
 footer-from: footer.md
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/hashicorp/go-plugin v1.4.0
+	github.com/hashicorp/go-version v1.3.0
 	github.com/iancoleman/orderedmap v0.2.0
 	github.com/imdario/mergo v0.3.11
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -326,6 +326,7 @@ type Config struct {
 	BaseDir      string       `yaml:"-"`
 	File         string       `yaml:"-"`
 	Formatter    string       `yaml:"formatter"`
+	Version      string       `yaml:"version"`
 	HeaderFrom   string       `yaml:"header-from"`
 	FooterFrom   string       `yaml:"footer-from"`
 	Sections     sections     `yaml:"sections"`
@@ -341,6 +342,7 @@ func DefaultConfig() *Config {
 		BaseDir:      "",
 		File:         "",
 		Formatter:    "",
+		Version:      "",
 		HeaderFrom:   "main.tf",
 		FooterFrom:   "",
 		Sections:     defaultSections(),

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionConstraint(t *testing.T) {
+	type tuple struct {
+		constraint string
+		version    string
+	}
+	tests := map[string]struct {
+		versions []tuple
+		wantErr  bool
+	}{
+		"NoRange": {
+			versions: []tuple{
+				{"", "1.2.3"},
+			},
+			wantErr: false,
+		},
+		"ValidConstraint": {
+			versions: []tuple{
+				{">= 1.0, < 1.2", "1.1.5"},
+				{"= 1.0", "1.0.0"},
+				{"1.0", "1.0.0"},
+				{">= 1.0", "1.2.3"},
+				{"~> 1.0", "1.1"},
+				{"~> 1.0", "1.2.3"},
+				{"~> 1.0.0", "1.0.7"},
+				{"~> 1.0.7", "1.0.7"},
+				{"~> 1.0.7", "1.0.8"},
+				{"~> 2.1.0-a", "2.1.0-beta"},
+				{">= 2.1.0-a", "2.1.0-beta"},
+				{">= 2.1.0-a", "2.1.1"},
+				{">= 2.1.0-a", "2.1.0"},
+				{"<= 2.1.0-a", "2.0.0"},
+			},
+			wantErr: false,
+		},
+		"MalformedCurrent": {
+			versions: []tuple{
+				{"> 1.0", "1.2.x"},
+			},
+			wantErr: true,
+		},
+		"InvalidConstraint": {
+			versions: []tuple{
+				{"< 1.0, < 1.2", "1.1.5"},
+				{"> 1.1, <= 1.2", "1.2.3"},
+				{"> 1.2, <= 1.1", "1.2.3"},
+				{"= 1.0", "1.1.5"},
+				{"~> 1.0", "2.0"},
+				{"~> 1.0.0", "1.2.3"},
+				{"~> 1.0.0", "1.1.0"},
+				{"~> 1.0.7", "1.0.4"},
+				{"~> 2.0", "2.1.0-beta"},
+				{"~> 2.1.0-a", "2.2.0"},
+				{"~> 2.1.0-a", "2.1.0"},
+				{"~> 2.1.0-a", "2.2.0-alpha"},
+				{"> 2.0", "2.1.0-beta"},
+				{">= 2.1.0-a", "2.1.1-beta"},
+				{">= 2.0.0", "2.1.0-beta"},
+				{">= 2.1.0-a", "2.1.1-beta"},
+			},
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			for _, v := range tt.versions {
+				err := checkConstraint(v.constraint, v.version)
+
+				if tt.wantErr {
+					assert.NotNil(err)
+				} else {
+					assert.Nil(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -43,6 +43,11 @@ func init() {
 	}
 }
 
+// Short return the version of the binary
+func Short() string {
+	return version
+}
+
 // Full return the full version of the binary including commit hash and build date
 func Full() string {
 	if !strings.HasSuffix(version, commitHash) {


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

terraform-docs version constraints is almost identical to the syntax
used by Terraform. A version constraint is a string literal containing
one or more condition, which are separated by commas.

```yaml
version: ">= 0.13.0, < 1.0.0"
```

Each condition consists of an operator and a version number. A version
number is a series of numbers separated by dots (e.g. `0.13.0`). Note
that version number should not have leading `v` in it.

Valid operators are as follow:

- `=` (or no operator): allows for exact version number.
- `!=`: exclude an exact version number.
- `>`, `>=`, `<`, and `<=`: comparisons against a specific version.
- `~>`: only the rightmost version component to increment.

Fixes #343

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Added new `TestVersionConstraint` set of tests.

[contribution process]: https://git.io/JtEzg
