### PR TITLE
In output-mode inject do not fail if file not found

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -185,9 +185,9 @@ flag) is not empty. Insersion behavior can be controlled by `output.mode` (or
 
 - `inject` (default)
 
-  Partially replace the `output-file` with generated output. This will fail if
-  `output-file` doesn't exist. Also will fail if `output-file` doesn't already
-  have surrounding comments.
+  Partially replace the `output-file` with generated output. This will create
+  the `output-file` if it doesn't exist. It will also append to `output-file`
+  if it doesn't have surrounding comments.
 
 - `replace`
 

--- a/internal/cli/testdata/writer/mode-inject-empty-file.golden
+++ b/internal/cli/testdata/writer/mode-inject-empty-file.golden
@@ -1,0 +1,3 @@
+<!-- BEGIN_TF_DOCS -->
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+<!-- END_TF_DOCS -->

--- a/internal/cli/testdata/writer/mode-inject-file-missing.golden
+++ b/internal/cli/testdata/writer/mode-inject-file-missing.golden
@@ -1,0 +1,3 @@
+<!-- BEGIN_TF_DOCS -->
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+<!-- END_TF_DOCS -->

--- a/internal/cli/testdata/writer/mode-inject-no-comment.golden
+++ b/internal/cli/testdata/writer/mode-inject-no-comment.golden
@@ -1,0 +1,22 @@
+# Foo
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+## Bar
+
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua.
+
+- Ut enim ad minim veniam
+- quis nostrud exercitation
+
+ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit
+
+## Baz
+
+esse cillum dolore eu fugiat nulla pariatur.
+
+<!-- BEGIN_TF_DOCS -->
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+<!-- END_TF_DOCS -->

--- a/internal/cli/testdata/writer/mode-inject-no-comment.md
+++ b/internal/cli/testdata/writer/mode-inject-no-comment.md
@@ -1,0 +1,18 @@
+# Foo
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+## Bar
+
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua.
+
+- Ut enim ad minim veniam
+- quis nostrud exercitation
+
+ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit
+
+## Baz
+
+esse cillum dolore eu fugiat nulla pariatur.

--- a/internal/cli/writer_test.go
+++ b/internal/cli/writer_test.go
@@ -80,8 +80,68 @@ func TestFileWriter(t *testing.T) {
 			wantErr:  false,
 			errMsg:   "",
 		},
+		"ModeInjectEmptyFile": {
+			file:     "empty-file.md",
+			mode:     "inject",
+			template: OutputTemplate,
+			begin:    outputBeginComment,
+			end:      outputEndComment,
+			writer:   &bytes.Buffer{},
+
+			expected: "mode-inject-empty-file",
+			wantErr:  false,
+			errMsg:   "",
+		},
+		"ModeInjectNoCommentAppend": {
+			file:     "mode-inject-no-comment.md",
+			mode:     "inject",
+			template: OutputTemplate,
+			begin:    outputBeginComment,
+			end:      outputEndComment,
+			writer:   &bytes.Buffer{},
+
+			expected: "mode-inject-no-comment",
+			wantErr:  false,
+			errMsg:   "",
+		},
+		"ModeInjectFileMissing": {
+			file:     "file-missing.md",
+			mode:     "inject",
+			template: OutputTemplate,
+			begin:    outputBeginComment,
+			end:      outputEndComment,
+			writer:   &bytes.Buffer{},
+
+			expected: "mode-inject-file-missing",
+			wantErr:  false,
+			errMsg:   "",
+		},
 		"ModeReplaceWithComment": {
 			file:     "mode-replace.md",
+			mode:     "replace",
+			template: OutputTemplate,
+			begin:    outputBeginComment,
+			end:      outputEndComment,
+			writer:   &bytes.Buffer{},
+
+			expected: "mode-replace-with-comment",
+			wantErr:  false,
+			errMsg:   "",
+		},
+		"ModeReplaceWithCommentEmptyFile": {
+			file:     "mode-replace.md",
+			mode:     "replace",
+			template: OutputTemplate,
+			begin:    outputBeginComment,
+			end:      outputEndComment,
+			writer:   &bytes.Buffer{},
+
+			expected: "mode-replace-with-comment",
+			wantErr:  false,
+			errMsg:   "",
+		},
+		"ModeReplaceWithCommentFileMissing": {
+			file:     "file-missing.md",
 			mode:     "replace",
 			template: OutputTemplate,
 			begin:    outputBeginComment,
@@ -118,18 +178,6 @@ func TestFileWriter(t *testing.T) {
 		},
 
 		// Error writes
-		"ModeInjectNoFile": {
-			file:     "file-missing.md",
-			mode:     "inject",
-			template: OutputTemplate,
-			begin:    outputBeginComment,
-			end:      outputEndComment,
-			writer:   nil,
-
-			expected: "",
-			wantErr:  true,
-			errMsg:   "open testdata/writer/file-missing.md: no such file or directory",
-		},
 		"EmptyTemplate": {
 			file:     "not-applicable.md",
 			mode:     "inject",
@@ -141,18 +189,6 @@ func TestFileWriter(t *testing.T) {
 			expected: "",
 			wantErr:  true,
 			errMsg:   "template is missing",
-		},
-		"EmptyFile": {
-			file:     "empty-file.md",
-			mode:     "inject",
-			template: OutputTemplate,
-			begin:    outputBeginComment,
-			end:      outputEndComment,
-			writer:   nil,
-
-			expected: "",
-			wantErr:  true,
-			errMsg:   "file content is empty",
 		},
 		"BeginCommentMissing": {
 			file:     "begin-comment-missing.md",


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

The following scenarios can happen for `--output-mode inject`:

- file exists, comments exist: inject output between comments
- file exists, comments not found: append output at the end of file
- file exists, but empty: save the whole output into the file
- file not found: create the target file and save the ooutput into it

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Adjusted the test cases and added new ones (in `writer_test.go`)

[contribution process]: https://git.io/JtEzg
