### PR TITLE
Add missing Resource.Mode to plugin-sdk

### DIFF
--- a/internal/terraform/resource.go
+++ b/internal/terraform/resource.go
@@ -91,6 +91,7 @@ func (rr resources) convert() []*terraformsdk.Resource {
 			Name:           r.Name,
 			ProviderName:   r.ProviderName,
 			ProviderSource: r.ProviderSource,
+			Mode:           r.Mode,
 			Version:        fmt.Sprintf("%v", r.Version.Raw()),
 			Position: terraformsdk.Position{
 				Filename: r.Position.Filename,

--- a/internal/terraform/resource_test.go
+++ b/internal/terraform/resource_test.go
@@ -31,6 +31,19 @@ func TestResourceSpec(t *testing.T) {
 	}
 	assert.Equal("tls_private_key.baz", resource.Spec())
 }
+func TestPluginSdkConversion(t *testing.T) {
+	assert := assert.New(t)
+	resource := Resource{
+		Type:           "private_key",
+		Name:           "baz",
+		ProviderName:   "tls",
+		ProviderSource: "hashicorp/tls",
+		Mode:           "managed",
+		Version:        types.String("latest"),
+	}
+	sdkResource := resources{&resource}.convert()[0]
+	assert.Equal(resource.Mode, sdkResource.Mode)
+}
 
 func TestResourceMode(t *testing.T) {
 	tests := map[string]struct {

--- a/internal/terraform/resource_test.go
+++ b/internal/terraform/resource_test.go
@@ -42,7 +42,12 @@ func TestPluginSdkConversion(t *testing.T) {
 		Version:        types.String("latest"),
 	}
 	sdkResource := resources{&resource}.convert()[0]
+	assert.Equal(resource.Type, sdkResource.Type)
+	assert.Equal(resource.Name, sdkResource.Name)
+	assert.Equal(resource.ProviderName, sdkResource.ProviderName)
+	assert.Equal(resource.ProviderSource, sdkResource.ProviderSource)
 	assert.Equal(resource.Mode, sdkResource.Mode)
+	assert.Equal(resource.Version, types.String(sdkResource.Version))
 }
 
 func TestResourceMode(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

fix for #492 bug. added missing field of the structure [Resource](https://github.com/terraform-docs/terraform-docs/blob/master/internal/terraform/resource.go#L22) the conversion method.

I have:

- [+] Read and followed terraform-docs' [contribution process].
- [+] All tests pass when I run `make test`.

### How has this code been tested

within the fix new test provided.

[contribution process]: https://git.io/JtEzg
