### PR TITLE
Normalize version to prevent malformed error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,9 +6,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/terraform-docs/terraform-docs/internal/version.version={{ .Version }}
-      - -X github.com/terraform-docs/terraform-docs/internal/version.commitHash={{ .ShortCommit }}
-      - -X github.com/terraform-docs/terraform-docs/internal/version.buildDate={{ .Date }}
+      - -X github.com/terraform-docs/terraform-docs/internal/version.commit={{ .ShortCommit }}
     goos:
       - darwin
       - linux

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ LICENSE       := MIT
 # Build variables
 BUILD_DIR    := bin
 COMMIT_HASH  ?= $(shell git rev-parse --short HEAD 2>/dev/null)
-BUILD_DATE   ?= $(shell date +%FT%T%z)
 CUR_VERSION  ?= $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "v0.0.0-$(COMMIT_HASH)")
 COVERAGE_OUT := coverage.out
 
@@ -26,9 +25,7 @@ GO_PACKAGE  := github.com/$(PROJECT_OWNER)/$(PROJECT_NAME)
 GOOS        ?= $(shell $(GO) env GOOS)
 GOARCH      ?= $(shell $(GO) env GOARCH)
 
-GOLDFLAGS   += -X $(GO_PACKAGE)/internal/version.version=$(CUR_VERSION)
-GOLDFLAGS   += -X $(GO_PACKAGE)/internal/version.commitHash=$(COMMIT_HASH)
-GOLDFLAGS   += -X $(GO_PACKAGE)/internal/version.buildDate=$(BUILD_DATE)
+GOLDFLAGS   += -X $(GO_PACKAGE)/internal/version.commit=$(COMMIT_HASH)
 
 GOBUILD     ?= CGO_ENABLED=0 $(GO) build -ldflags="$(GOLDFLAGS)"
 GORUN       ?= GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) run

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,10 +23,11 @@ import (
 	"github.com/terraform-docs/terraform-docs/cmd/pretty"
 	"github.com/terraform-docs/terraform-docs/cmd/tfvars"
 	"github.com/terraform-docs/terraform-docs/cmd/toml"
-	"github.com/terraform-docs/terraform-docs/cmd/version"
+	versioncmd "github.com/terraform-docs/terraform-docs/cmd/version"
 	"github.com/terraform-docs/terraform-docs/cmd/xml"
 	"github.com/terraform-docs/terraform-docs/cmd/yaml"
 	"github.com/terraform-docs/terraform-docs/internal/cli"
+	"github.com/terraform-docs/terraform-docs/internal/version"
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -98,7 +99,7 @@ func NewCommand() *cobra.Command {
 
 	// other subcommands
 	cmd.AddCommand(completion.NewCommand())
-	cmd.AddCommand(version.NewCommand())
+	cmd.AddCommand(versioncmd.NewCommand())
 
 	return cmd
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -26,7 +26,7 @@ func NewCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print the version number of terraform-docs",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("terraform-docs version %s\n", Full())
+			fmt.Printf("terraform-docs version %s\n", version.Full())
 			plugins, err := plugin.Discover()
 			if err != nil {
 				return
@@ -45,9 +45,4 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	return cmd
-}
-
-// Full returns the full version of the binary
-func Full() string {
-	return version.Full()
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -90,7 +90,7 @@ func PreRunEFunc(config *Config) func(*cobra.Command, []string) error { //nolint
 			return fmt.Errorf("unable to decode config, %w", err)
 		}
 
-		if err := checkConstraint(config.Version, version.Short()); err != nil {
+		if err := checkConstraint(config.Version, version.Core()); err != nil {
 			return err
 		}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,46 +13,38 @@ package version
 import (
 	"fmt"
 	"runtime"
-	"strings"
-	"time"
 )
 
 // current version
-const dev = "v0.13.0"
-
-// Provisioned by ldflags
-var (
-	version    string
-	commitHash string
-	buildDate  string
+const (
+	coreVersion = "0.14.0"
+	prerelease  = "alpha"
 )
 
-// Load defaults for info variables
-func init() {
-	if version == "" {
-		version = dev
-	}
-	if version == "v0.0.0-" { // building in a directory which is not a git repository
-		version = dev
-	}
-	if commitHash == "" {
-		commitHash = dev
-	}
-	if buildDate == "" {
-		buildDate = time.Now().Format(time.RFC3339)
-	}
+// Provisioned by ldflags
+var commit string
+
+// Core return the core version.
+func Core() string {
+	return coreVersion
 }
 
-// Short return the version of the binary
+// Short return the version with pre-release, if available.
 func Short() string {
-	return version
+	v := coreVersion
+
+	if prerelease != "" {
+		v += "-" + prerelease
+	}
+
+	return v
 }
 
-// Full return the full version of the binary including commit hash and build date
+// Full return the full version including pre-release, commit hash, runtime os and arch.
 func Full() string {
-	if !strings.HasSuffix(version, commitHash) {
-		version += " " + commitHash
+	if commit != "" && commit[:1] != " " {
+		commit = " " + commit
 	}
-	osArch := runtime.GOOS + "/" + runtime.GOARCH
-	return fmt.Sprintf("%s %s BuildDate: %s", version, osArch, buildDate)
+
+	return fmt.Sprintf("v%s%s %s/%s", Short(), commit, runtime.GOOS, runtime.GOARCH)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

As part of this normalization the following is made sure:

- leading `v` is shown in `-v, --version` and `version` command
- commit hash is shown in `-v, --version` and `version` command
- build date is removed
- version core (without pre-release) is used for constraint comparison

Fixes #495

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- `go run` against `examples/` folder with `version` config enabled
- build with `make build` and run against `examples/` folder with `version` config enabled
- `go run main.go --version`
- build with `make build` and run with `--version`

[contribution process]: https://git.io/JtEzg
