### PR TITLE
Fix base template not found on Windows

### DIFF
--- a/internal/format/util.go
+++ b/internal/format/util.go
@@ -14,7 +14,6 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -80,7 +79,7 @@ func readTemplateItems(efs embed.FS, prefix string) []*template.Item {
 	}
 
 	for _, f := range files {
-		content, err := efs.ReadFile(filepath.Join("templates", f.Name()))
+		content, err := efs.ReadFile("templates/" + f.Name())
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Path separator of embed.FS is always a forward slash, even on Windows.

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually built and tested on Windows.

[contribution process]: https://git.io/JtEzg
