### PR TITLE
updating how-to doc for correct Include Examples syntax

### DIFF
--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -182,7 +182,7 @@ content: |-
   ## Example
 
   ```hcl
-  {{ file "example-1/main.tf" }}
+  {{ include "examples/example-1/main.tf" }}
   ```
 
   {{ .Inputs }}


### PR DESCRIPTION
changing file to include in the Include Example section of the How To Docs addressing Issue #512 