### PR TITLE
Ignore extracting versions from terraform.lock.hcl

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,8 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&config.HeaderFrom, "header-from", "main.tf", "relative path of a file to read header from")
 	cmd.PersistentFlags().StringVar(&config.FooterFrom, "footer-from", "", "relative path of a file to read footer from (default \"\")")
 
+	cmd.PersistentFlags().BoolVar(&config.Settings.LockFile, "lockfile", true, "read .terraform.lock.hcl if exist")
+
 	cmd.PersistentFlags().BoolVar(&config.OutputValues.Enabled, "output-values", false, "inject output values into outputs (default false)")
 	cmd.PersistentFlags().StringVar(&config.OutputValues.From, "output-values-from", "", "inject output values from file into outputs (default \"\")")
 

--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -32,6 +32,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -32,6 +32,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/asciidoc.md
+++ b/docs/reference/asciidoc.md
@@ -35,6 +35,7 @@ terraform-docs asciidoc [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -30,6 +30,7 @@ terraform-docs json [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -34,6 +34,7 @@ terraform-docs markdown document [PATH] [flags]
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --html                        use HTML tags in genereted output (default true)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -34,6 +34,7 @@ terraform-docs markdown table [PATH] [flags]
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --html                        use HTML tags in genereted output (default true)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -37,6 +37,7 @@ terraform-docs markdown [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/pretty.md
+++ b/docs/reference/pretty.md
@@ -30,6 +30,7 @@ terraform-docs pretty [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/terraform-docs.md
+++ b/docs/reference/terraform-docs.md
@@ -24,6 +24,7 @@ terraform-docs [PATH] [flags]
       --header-from string          relative path of a file to read header from (default "main.tf")
   -h, --help                        help for terraform-docs
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/tfvars-hcl.md
+++ b/docs/reference/tfvars-hcl.md
@@ -30,6 +30,7 @@ terraform-docs tfvars hcl [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/tfvars-json.md
+++ b/docs/reference/tfvars-json.md
@@ -29,6 +29,7 @@ terraform-docs tfvars json [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/tfvars.md
+++ b/docs/reference/tfvars.md
@@ -25,6 +25,7 @@ Generate terraform.tfvars of inputs.
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/toml.md
+++ b/docs/reference/toml.md
@@ -29,6 +29,7 @@ terraform-docs toml [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/xml.md
+++ b/docs/reference/xml.md
@@ -29,6 +29,7 @@ terraform-docs xml [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -29,6 +29,7 @@ terraform-docs yaml [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")
       --output-mode string          output to file method [inject, replace] (default "inject")

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -98,6 +98,7 @@ settings:
   escape: true
   html: true
   indent: 2
+  lockfile: true
   required: true
   sensitive: true
   type: true

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -373,6 +373,7 @@ type settings struct {
 	Escape      bool `mapstructure:"escape"`
 	HTML        bool `mapstructure:"html"`
 	Indent      int  `mapstructure:"indent"`
+	LockFile    bool `mapstructure:"lockfile"`
 	Required    bool `mapstructure:"required"`
 	Sensitive   bool `mapstructure:"sensitive"`
 	Type        bool `mapstructure:"type"`
@@ -387,6 +388,7 @@ func defaultSettings() settings {
 		Escape:      true,
 		HTML:        true,
 		Indent:      2,
+		LockFile:    true,
 		Required:    true,
 		Sensitive:   true,
 		Type:        true,
@@ -468,6 +470,9 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	settings.ShowFooter = c.Sections.footer
 	options.ShowFooter = settings.ShowFooter
 	options.FooterFromFile = c.FooterFrom
+
+	// terraform.lock.hcl file
+	options.UseLockFile = c.Settings.LockFile
 
 	// sections
 	settings.ShowDataSources = c.Sections.dataSources

--- a/internal/terraform/module.go
+++ b/internal/terraform/module.go
@@ -411,14 +411,17 @@ func loadProviders(tfmodule *tfconfig.Module, options *Options) []*Provider {
 		Provider []provider `hcl:"provider,block"`
 	}
 	lock := make(map[string]provider)
-	var lf lockfile
 
-	filename := filepath.Join(options.Path, ".terraform.lock.hcl")
-	if err := hclsimple.DecodeFile(filename, nil, &lf); err == nil {
-		for i := range lf.Provider {
-			segments := strings.Split(lf.Provider[i].Name, "/")
-			name := segments[len(segments)-1]
-			lock[name] = lf.Provider[i]
+	if options.UseLockFile {
+		var lf lockfile
+
+		filename := filepath.Join(options.Path, ".terraform.lock.hcl")
+		if err := hclsimple.DecodeFile(filename, nil, &lf); err == nil {
+			for i := range lf.Provider {
+				segments := strings.Split(lf.Provider[i].Name, "/")
+				name := segments[len(segments)-1]
+				lock[name] = lf.Provider[i]
+			}
 		}
 	}
 

--- a/internal/terraform/options.go
+++ b/internal/terraform/options.go
@@ -31,6 +31,7 @@ type Options struct {
 	HeaderFromFile   string
 	ShowFooter       bool
 	FooterFromFile   string
+	UseLockFile      bool
 	SortBy           *SortBy
 	OutputValues     bool
 	OutputValuesPath string
@@ -44,6 +45,7 @@ func NewOptions() *Options {
 		HeaderFromFile:   "main.tf",
 		ShowFooter:       false,
 		FooterFromFile:   "",
+		UseLockFile:      true,
 		SortBy:           &SortBy{Name: false, Required: false, Type: false},
 		OutputValues:     false,
 		OutputValuesPath: "",


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

New flag, `--lockfile`, is added to control whether ignore reading
`.terraform.lock.hcl` file in an attempt to extract the exact version of
provider being used or not. Default is true.

If set to true, exact version of provider available in lock file at the
time of execution will be extracted. If set to false, the version in `.tf`
file will be used (either exact, or a constrained version: >=, ~>, ...)

Fixes #517

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

New test case added to `TestLoadProviders` to read test module with the lockfile.

[contribution process]: https://git.io/JtEzg
