### PR TITLE
Attempt looking up config file in .config folder

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -39,10 +39,13 @@ $ tree
 $ terraform-docs -c .tfdocs-config.yml .
 ```
 
-As of `v0.13.0`, the order for looking for config file is:
+As of `v0.13.0`, the order for looking for config file is *(2 and 4 were added
+in `v0.15.0`)*:
 
 1. root of module directory
+1. `.config/` folder at root of module directory
 1. current directory
+1. `.config/` folder at current directory
 1. `$HOME/.tfdocs.d/`
 
 if `.terraform-docs.yml` is found in any of the folders above, that will take

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -61,9 +61,11 @@ func PreRunEFunc(config *Config) func(*cobra.Command, []string) error { //nolint
 			v.SetConfigType("yml")
 		}
 
-		v.AddConfigPath(args[0])           // first look at module root
-		v.AddConfigPath(".")               // then current directory
-		v.AddConfigPath("$HOME/.tfdocs.d") // and finally $HOME/.tfdocs.d/
+		v.AddConfigPath(args[0])              // first look at module root
+		v.AddConfigPath(args[0] + "/.config") // then .config/ folder at module root
+		v.AddConfigPath(".")                  // then current directory
+		v.AddConfigPath(".config")            // then .config/ folder at current directory
+		v.AddConfigPath("$HOME/.tfdocs.d")    // and finally $HOME/.tfdocs.d/
 
 		if err := v.ReadInConfig(); err != nil {
 			var perr *os.PathError


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

The updated order of trying to look up for .terraform-docs.yml config
file, now, is:

1. root of module directory
2. `.config/` folder at root of module directory
3. current directory
4. `.config/` folder at current directory
5. `$HOME/.tfdocs.d/`

Fixes #531

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually created `.config/` folder in various places and made sure it is being picked up.

[contribution process]: https://git.io/JtEzg
