### PR TITLE
Properly format indented code blocks

### DIFF
--- a/internal/template/sanitizer.go
+++ b/internal/template/sanitizer.go
@@ -55,7 +55,16 @@ func sanitizeSection(s string, settings *print.Settings) string {
 			if !strings.HasSuffix(segment, "\n") {
 				lastbreak = "\n"
 			}
-			segment = fmt.Sprintf("```%s%s```", segment, lastbreak)
+
+			// Adjust indention and linebreak for indented codeblock
+			// https://github.com/terraform-docs/terraform-docs/issues/521
+			lastindent := ""
+			lines := strings.Split(segment, "\n")
+			if len(strings.TrimSpace(lines[len(lines)-1])) == 0 {
+				lastbreak = ""
+			}
+
+			segment = fmt.Sprintf("```%s%s%s```", segment, lastindent, lastbreak)
 			return segment
 		},
 	)

--- a/internal/template/testdata/section/complex.expected
+++ b/internal/template/testdata/section/complex.expected
@@ -28,6 +28,16 @@ module "foo_bar" {
 }
 ```
 
+1. Entry one with code
+
+    ```json
+    {
+      "key": "value"
+    }
+    ```
+
+1. This line should not be broken
+
 Here is some trailing text after code block,
 followed by another line of text.
 

--- a/internal/template/testdata/section/complex.golden
+++ b/internal/template/testdata/section/complex.golden
@@ -28,6 +28,16 @@ module "foo_bar" {
 }
 ```
 
+1. Entry one with code
+
+    ```json
+    {
+      "key": "value"
+    }
+    ```
+
+1. This line should not be broken
+
 Here is some trailing text after code block,
 followed by another line of text.
 


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

If a code block (surrounded by triple backticks) are indented, in other
words the code block is placed inside ordered or unordered list, the
closing backticks of codeblock should honor the original indentation
properly.


Fixes #521 

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Updated `complex.golden` test case to incorporate an indented code block and make sure the tests are passing.

[contribution process]: https://git.io/JtEzg
