### PR TITLE
Add 'HideEmpy' section bool flag

### DIFF
--- a/cmd/asciidoc/asciidoc.go
+++ b/cmd/asciidoc/asciidoc.go
@@ -33,6 +33,7 @@ func NewCommand(runtime *cli.Runtime, config *cli.Config) *cobra.Command {
 	// flags
 	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
+	cmd.PersistentFlags().BoolVar(&config.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
 	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of AsciiDoc sections [1, 2, 3, 4, 5]")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")

--- a/cmd/asciidoc/asciidoc.go
+++ b/cmd/asciidoc/asciidoc.go
@@ -33,7 +33,7 @@ func NewCommand(runtime *cli.Runtime, config *cli.Config) *cobra.Command {
 	// flags
 	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
-	cmd.PersistentFlags().BoolVar(&config.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
+	cmd.PersistentFlags().BoolVar(&config.Settings.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
 	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of AsciiDoc sections [1, 2, 3, 4, 5]")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")

--- a/cmd/markdown/markdown.go
+++ b/cmd/markdown/markdown.go
@@ -35,7 +35,7 @@ func NewCommand(runtime *cli.Runtime, config *cli.Config) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Escape, "escape", true, "escape special characters")
 	cmd.PersistentFlags().BoolVar(&config.Settings.HTML, "html", true, "use HTML tags in genereted output")
-	cmd.PersistentFlags().BoolVar(&config.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
+	cmd.PersistentFlags().BoolVar(&config.Settings.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
 	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of Markdown sections [1, 2, 3, 4, 5]")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")

--- a/cmd/markdown/markdown.go
+++ b/cmd/markdown/markdown.go
@@ -35,6 +35,7 @@ func NewCommand(runtime *cli.Runtime, config *cli.Config) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Escape, "escape", true, "escape special characters")
 	cmd.PersistentFlags().BoolVar(&config.Settings.HTML, "html", true, "use HTML tags in genereted output")
+	cmd.PersistentFlags().BoolVar(&config.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
 	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of Markdown sections [1, 2, 3, 4, 5]")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")

--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -31,6 +31,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide-empty                  hide empty sections (default false)
       --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -31,6 +31,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide-empty                  hide empty sections (default false)
       --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)

--- a/docs/reference/asciidoc.md
+++ b/docs/reference/asciidoc.md
@@ -22,6 +22,7 @@ terraform-docs asciidoc [PATH] [flags]
       --anchor       create anchor links (default true)
       --default      show Default column or section (default true)
   -h, --help         help for asciidoc
+      --hide-empty   hide empty sections (default false)
       --indent int   indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --required     show Required column or section (default true)
       --sensitive    show Sensitive column or section (default true)

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -32,6 +32,7 @@ terraform-docs markdown document [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide-empty                  hide empty sections (default false)
       --html                        use HTML tags in genereted output (default true)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -31,8 +31,8 @@ terraform-docs markdown table [PATH] [flags]
       --escape                      escape special characters (default true)
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
-      --hide-empty                  hide empty sections (default false)
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide-empty                  hide empty sections (default false)
       --html                        use HTML tags in genereted output (default true)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -31,6 +31,7 @@ terraform-docs markdown table [PATH] [flags]
       --escape                      escape special characters (default true)
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
+      --hide-empty                  hide empty sections (default false)
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --html                        use HTML tags in genereted output (default true)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -38,7 +38,6 @@ terraform-docs markdown [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
-      --hide-empty                  hide empty sections (default false)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -23,6 +23,7 @@ terraform-docs markdown [PATH] [flags]
       --default      show Default column or section (default true)
       --escape       escape special characters (default true)
   -h, --help         help for markdown
+      --hide-empty   hide empty sections (default false)
       --html         use HTML tags in genereted output (default true)
       --indent int   indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --required     show Required column or section (default true)
@@ -37,6 +38,7 @@ terraform-docs markdown [PATH] [flags]
       --footer-from string          relative path of a file to read footer from (default "")
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
+      --hide-empty                  hide empty sections (default false)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -99,7 +99,7 @@ settings:
   default: true
   description: false
   escape: true
-  hideempty: false
+  hide-empty: false
   html: true
   indent: 2
   lockfile: true

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -99,6 +99,7 @@ settings:
   default: true
   description: false
   escape: true
+  hideempty: false
   html: true
   indent: 2
   lockfile: true

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
-	github.com/terraform-docs/plugin-sdk v0.3.1-0.20210512170044-49b620c0a2da
+	github.com/terraform-docs/plugin-sdk v0.3.1-0.20210825180722-c52e9860f575
 	github.com/terraform-docs/terraform-config-inspect v0.0.0-20210728164355-9c1f178932fa
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	honnef.co/go/tools v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/terraform-docs/plugin-sdk v0.3.1-0.20210512170044-49b620c0a2da h1:WJXjngYRi9rtvzFFKjYuiWpax9R6tEiAA9givVSA4tw=
-github.com/terraform-docs/plugin-sdk v0.3.1-0.20210512170044-49b620c0a2da/go.mod h1:3G+0nZTeaMF1c5CZh8cOEYeNq0kUL6+DlQOVcxK7eCQ=
+github.com/terraform-docs/plugin-sdk v0.3.1-0.20210825180722-c52e9860f575 h1:pwOvvonyymFBE2YE5Yx1M236lH4WT9i8sgVYC4KMsgE=
+github.com/terraform-docs/plugin-sdk v0.3.1-0.20210825180722-c52e9860f575/go.mod h1:3G+0nZTeaMF1c5CZh8cOEYeNq0kUL6+DlQOVcxK7eCQ=
 github.com/terraform-docs/terraform-config-inspect v0.0.0-20210728164355-9c1f178932fa h1:wdyf3TobwYFwsqnUGJcjdNHxKfwHPFbaOknBJehnF1M=
 github.com/terraform-docs/terraform-config-inspect v0.0.0-20210728164355-9c1f178932fa/go.mod h1:GtanFwTsRRXScYHOMb5h4K18XQBFeS2tXat9/LrPtPc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -23,6 +23,8 @@ var flagMappings = map[string]string{
 	"header-from": "header-from",
 	"footer-from": "footer-from",
 
+	"hide-empty": "hide-empty",
+
 	"show": "sections.show",
 	"hide": "sections.hide",
 
@@ -59,6 +61,7 @@ type Config struct {
 	HeaderFrom    string       `mapstructure:"header-from"`
 	FooterFrom    string       `mapstructure:"footer-from"`
 	Content       string       `mapstructure:"content"`
+	HideEmpty     bool         `mapstructure:"hide-empty"`
 	Sections      sections     `mapstructure:"sections"`
 	Output        output       `mapstructure:"output"`
 	OutputValues  outputvalues `mapstructure:"output-values"`
@@ -80,6 +83,7 @@ func DefaultConfig() *Config {
 		HeaderFrom:    "main.tf",
 		FooterFrom:    "",
 		Content:       "",
+		HideEmpty:     false,
 		Sections:      defaultSections(),
 		Output:        defaultOutput(),
 		OutputValues:  defaultOutputValues(),
@@ -495,6 +499,7 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	settings.ShowProviders = c.Sections.providers
 	settings.ShowRequirements = c.Sections.requirements
 	settings.ShowResources = c.Sections.resources
+	settings.HideEmpty = c.HideEmpty
 
 	// output values
 	settings.OutputValues = c.OutputValues.Enabled

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -61,7 +61,6 @@ type Config struct {
 	HeaderFrom    string       `mapstructure:"header-from"`
 	FooterFrom    string       `mapstructure:"footer-from"`
 	Content       string       `mapstructure:"content"`
-	HideEmpty     bool         `mapstructure:"hide-empty"`
 	Sections      sections     `mapstructure:"sections"`
 	Output        output       `mapstructure:"output"`
 	OutputValues  outputvalues `mapstructure:"output-values"`
@@ -83,7 +82,6 @@ func DefaultConfig() *Config {
 		HeaderFrom:    "main.tf",
 		FooterFrom:    "",
 		Content:       "",
-		HideEmpty:     false,
 		Sections:      defaultSections(),
 		Output:        defaultOutput(),
 		OutputValues:  defaultOutputValues(),
@@ -383,6 +381,7 @@ type settings struct {
 	Default     bool `mapstructure:"default"`
 	Description bool `mapstructure:"description"`
 	Escape      bool `mapstructure:"escape"`
+	HideEmpty   bool `mapstructure:"hide-empty"`
 	HTML        bool `mapstructure:"html"`
 	Indent      int  `mapstructure:"indent"`
 	LockFile    bool `mapstructure:"lockfile"`
@@ -398,6 +397,7 @@ func defaultSettings() settings {
 		Default:     true,
 		Description: false,
 		Escape:      true,
+		HideEmpty:   false,
 		HTML:        true,
 		Indent:      2,
 		LockFile:    true,
@@ -499,7 +499,7 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	settings.ShowProviders = c.Sections.providers
 	settings.ShowRequirements = c.Sections.requirements
 	settings.ShowResources = c.Sections.resources
-	settings.HideEmpty = c.HideEmpty
+	settings.HideEmpty = c.Settings.HideEmpty
 
 	// output values
 	settings.OutputValues = c.OutputValues.Enabled

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -287,7 +287,7 @@ func checkConstraint(versionRange string, currentVersion string) error {
 }
 
 // generateContent extracts print.Settings and terraform.Options from normalized
-// Config and generates the output content for the module (and submodules if avialble)
+// Config and generates the output content for the module (and submodules if availble)
 // and write the result to the output (either stdout or a file).
 func generateContent(config *Config) error {
 	settings, options := config.extract()
@@ -300,7 +300,7 @@ func generateContent(config *Config) error {
 
 	formatter, err := format.Factory(config.Formatter, settings)
 
-	// formatter is unkowns, this might mean that the intended formatter is
+	// formatter is unknown, this might mean that the intended formatter is
 	// coming from a plugin. We are going to attempt to find a plugin with
 	// that name and generate the content with it or error out if not found.
 	if err != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -39,7 +39,7 @@ type Runtime struct {
 	cmd *cobra.Command
 }
 
-// NewRuntime retruns new instance of Runtime. If `config` is not provided
+// NewRuntime returns new instance of Runtime. If `config` is not provided
 // default config will be used.
 func NewRuntime(config *Config) *Runtime {
 	if config == nil {
@@ -287,7 +287,7 @@ func checkConstraint(versionRange string, currentVersion string) error {
 }
 
 // generateContent extracts print.Settings and terraform.Options from normalized
-// Config and generates the output content for the module (and submodules if availble)
+// Config and generates the output content for the module (and submodules if available)
 // and write the result to the output (either stdout or a file).
 func generateContent(config *Config) error {
 	settings, options := config.extract()

--- a/internal/format/asciidoc_document_test.go
+++ b/internal/format/asciidoc_document_test.go
@@ -39,6 +39,12 @@ func TestAsciidocDocument(t *testing.T) {
 				Path: "empty",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 		"HideAll": {
 			settings: print.Settings{},
 			options: terraform.Options{
@@ -117,12 +123,6 @@ func TestAsciidocDocument(t *testing.T) {
 			options: terraform.Options{
 				OutputValues:     true,
 				OutputValuesPath: "output_values.json",
-			},
-		},
-		"HideEmpty": {
-			settings: testutil.WithSections(testutil.WithHideEmpty()),
-			options: terraform.Options{
-				Path: "empty",
 			},
 		},
 

--- a/internal/format/asciidoc_document_test.go
+++ b/internal/format/asciidoc_document_test.go
@@ -119,6 +119,12 @@ func TestAsciidocDocument(t *testing.T) {
 				OutputValuesPath: "output_values.json",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 
 		// Only section
 		"OnlyDataSources": {

--- a/internal/format/asciidoc_table_test.go
+++ b/internal/format/asciidoc_table_test.go
@@ -39,6 +39,12 @@ func TestAsciidocTable(t *testing.T) {
 				Path: "empty",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 		"HideAll": {
 			settings: print.Settings{},
 			options: terraform.Options{
@@ -117,12 +123,6 @@ func TestAsciidocTable(t *testing.T) {
 			options: terraform.Options{
 				OutputValues:     true,
 				OutputValuesPath: "output_values.json",
-			},
-		},
-		"HideEmpty": {
-			settings: testutil.WithSections(testutil.WithHideEmpty()),
-			options: terraform.Options{
-				Path: "empty",
 			},
 		},
 

--- a/internal/format/asciidoc_table_test.go
+++ b/internal/format/asciidoc_table_test.go
@@ -119,6 +119,12 @@ func TestAsciidocTable(t *testing.T) {
 				OutputValuesPath: "output_values.json",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 
 		// Only section
 		"OnlyDataSources": {

--- a/internal/format/markdown_document_test.go
+++ b/internal/format/markdown_document_test.go
@@ -39,6 +39,12 @@ func TestMarkdownDocument(t *testing.T) {
 				Path: "empty",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 		"HideAll": {
 			settings: print.Settings{},
 			options: terraform.Options{
@@ -163,12 +169,6 @@ func TestMarkdownDocument(t *testing.T) {
 			options: terraform.Options{
 				OutputValues:     true,
 				OutputValuesPath: "output_values.json",
-			},
-		},
-		"HideEmpty": {
-			settings: testutil.WithSections(testutil.WithHideEmpty()),
-			options: terraform.Options{
-				Path: "empty",
 			},
 		},
 

--- a/internal/format/markdown_document_test.go
+++ b/internal/format/markdown_document_test.go
@@ -165,6 +165,12 @@ func TestMarkdownDocument(t *testing.T) {
 				OutputValuesPath: "output_values.json",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 
 		// Only section
 		"OnlyDataSources": {

--- a/internal/format/markdown_table_test.go
+++ b/internal/format/markdown_table_test.go
@@ -165,6 +165,12 @@ func TestMarkdownTable(t *testing.T) {
 				OutputValuesPath: "output_values.json",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 
 		// Only section
 		"OnlyDataSources": {

--- a/internal/format/markdown_table_test.go
+++ b/internal/format/markdown_table_test.go
@@ -39,6 +39,12 @@ func TestMarkdownTable(t *testing.T) {
 				Path: "empty",
 			},
 		},
+		"HideEmpty": {
+			settings: testutil.WithSections(testutil.WithHideEmpty()),
+			options: terraform.Options{
+				Path: "empty",
+			},
+		},
 		"HideAll": {
 			settings: print.Settings{},
 			options: terraform.Options{
@@ -163,12 +169,6 @@ func TestMarkdownTable(t *testing.T) {
 			options: terraform.Options{
 				OutputValues:     true,
 				OutputValuesPath: "output_values.json",
-			},
-		},
-		"HideEmpty": {
-			settings: testutil.WithSections(testutil.WithHideEmpty()),
-			options: terraform.Options{
-				Path: "empty",
 			},
 		},
 

--- a/internal/format/templates/asciidoc_document_inputs.tmpl
+++ b/internal/format/templates/asciidoc_document_inputs.tmpl
@@ -1,9 +1,14 @@
 {{- if .Settings.ShowInputs -}}
     {{- if .Settings.ShowRequired -}}
-        {{ indent 0 "=" }} Required Inputs
-        {{ if not .Module.RequiredInputs }}
-            No required inputs.
+        {{- if not .Module.RequiredInputs -}}
+            {{- if not .Settings.HideEmpty -}}
+                {{- indent 0 "=" }} Required Inputs
+
+                No required inputs.
+            {{ end -}}
         {{ else }}
+            {{- indent 0 "=" }} Required Inputs
+
             The following input variables are required:
             {{- range .Module.RequiredInputs }}
                 {{ printf "\n" }}
@@ -22,10 +27,15 @@
                 {{- end }}
             {{- end }}
         {{- end }}
-        {{ indent 0 "=" }} Optional Inputs
-        {{ if not .Module.OptionalInputs }}
-            No optional inputs.
+        {{- if not .Module.OptionalInputs -}}
+            {{- if not .Settings.HideEmpty -}}
+                {{- indent 0 "=" }} Optional Inputs
+
+                No optional inputs.
+            {{ end }}
         {{ else }}
+            {{- indent 0 "=" }} Optional Inputs
+
             The following input variables are optional (have default values):
             {{- range .Module.OptionalInputs }}
                 {{ printf "\n" }}
@@ -45,10 +55,15 @@
             {{- end }}
         {{ end }}
     {{ else -}}
-        {{ indent 0 "=" }} Inputs
-        {{ if not .Module.Inputs }}
-            No inputs.
+        {{- if not .Module.Inputs -}}
+            {{- if not .Settings.HideEmpty -}}
+                {{- indent 0 "=" }} Inputs
+
+                No inputs.
+            {{ end }}
         {{ else }}
+            {{- indent 0 "=" }} Inputs
+
             The following input variables are supported:
             {{- range .Module.Inputs }}
                 {{ printf "\n" }}

--- a/internal/format/templates/asciidoc_document_modules.tmpl
+++ b/internal/format/templates/asciidoc_document_modules.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowModuleCalls -}}
-    {{ indent 0 "=" }} Modules
-    {{ if not .Module.ModuleCalls }}
-        No modules.
+    {{- if not .Module.ModuleCalls -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Modules
+
+            No modules.
+        {{ end -}}
     {{ else }}
+        {{- indent 0 "=" }} Modules
+
         The following Modules are called:
         {{- range .Module.ModuleCalls }}
 

--- a/internal/format/templates/asciidoc_document_outputs.tmpl
+++ b/internal/format/templates/asciidoc_document_outputs.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowOutputs -}}
-    {{ indent 0 "=" }} Outputs
-    {{ if not .Module.Outputs }}
-        No outputs.
+    {{- if not .Module.Outputs -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Outputs
+
+            No outputs.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Outputs
+
         The following outputs are exported:
         {{- range .Module.Outputs }}
 
@@ -19,5 +24,5 @@
                 {{- end }}
             {{ end }}
         {{ end }}
-    {{ end }}
+    {{- end }}
 {{ end -}}

--- a/internal/format/templates/asciidoc_document_providers.tmpl
+++ b/internal/format/templates/asciidoc_document_providers.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowProviders -}}
-    {{ indent 0 "=" }} Providers
-    {{ if not .Module.Providers }}
-        No providers.
+    {{- if not .Module.Providers -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Providers
+
+            No providers.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Providers
+
         The following providers are used by this module:
         {{- range .Module.Providers }}
             {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}

--- a/internal/format/templates/asciidoc_document_requirements.tmpl
+++ b/internal/format/templates/asciidoc_document_requirements.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowRequirements -}}
-    {{ indent 0 "=" }} Requirements
-    {{ if not .Module.Requirements }}
-        No requirements.
+    {{- if not .Module.Requirements -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Requirements
+
+            No requirements.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Requirements
+
         The following requirements are needed by this module:
         {{- range .Module.Requirements }}
             {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}

--- a/internal/format/templates/asciidoc_document_resources.tmpl
+++ b/internal/format/templates/asciidoc_document_resources.tmpl
@@ -1,8 +1,13 @@
 {{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
-    {{ indent 0 "=" }} Resources
-    {{ if not .Module.Resources }}
-        No resources.
+    {{- if not .Module.Resources -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Resources
+
+            No resources.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Resources
+
         The following resources are used by this module:
         {{ range .Module.Resources }}
             {{- $isResource := and $.Settings.ShowResources ( eq "resource" (printf "%s" .GetMode)) }}

--- a/internal/format/templates/asciidoc_table_inputs.tmpl
+++ b/internal/format/templates/asciidoc_table_inputs.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowInputs -}}
-    {{ indent 0 "=" }} Inputs
-    {{ if not .Module.Inputs }}
-        No inputs.
+    {{- if not .Module.Inputs -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Inputs
+
+            No inputs.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Inputs
+
         [cols="a,a{{ if .Settings.ShowType }},a{{ end }}{{ if .Settings.ShowDefault }},a{{ end }}{{ if .Settings.ShowRequired }},a{{ end }}",options="header,autowidth"]
         |===
         |Name |Description

--- a/internal/format/templates/asciidoc_table_modules.tmpl
+++ b/internal/format/templates/asciidoc_table_modules.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowModuleCalls -}}
-    {{ indent 0 "=" }} Modules
-    {{ if not .Module.ModuleCalls }}
-        No modules.
+    {{- if not .Module.ModuleCalls -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Modules
+
+            No modules.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Modules
+
         [cols="a,a,a",options="header,autowidth"]
         |===
         |Name |Source |Version

--- a/internal/format/templates/asciidoc_table_outputs.tmpl
+++ b/internal/format/templates/asciidoc_table_outputs.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowOutputs -}}
-    {{ indent 0 "=" }} Outputs
-    {{ if not .Module.Outputs }}
-        No outputs.
+    {{- if not .Module.Outputs -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Outputs
+
+            No outputs.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Outputs
+
         [cols="a,a{{ if .Settings.OutputValues }},a{{ if $.Settings.ShowSensitivity }},a{{ end }}{{ end }}",options="header,autowidth"]
         |===
         |Name |Description{{ if .Settings.OutputValues }} |Value{{ if $.Settings.ShowSensitivity }} |Sensitive{{ end }}{{ end }}

--- a/internal/format/templates/asciidoc_table_providers.tmpl
+++ b/internal/format/templates/asciidoc_table_providers.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowProviders -}}
-    {{ indent 0 "=" }} Providers
-    {{ if not .Module.Providers }}
-        No providers.
+    {{- if not .Module.Providers -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Providers
+
+            No providers.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "=" }} Providers
+
         [cols="a,a",options="header,autowidth"]
         |===
         |Name |Version

--- a/internal/format/templates/asciidoc_table_requirements.tmpl
+++ b/internal/format/templates/asciidoc_table_requirements.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowRequirements -}}
-    {{ indent 0 "=" }} Requirements
-    {{ if not .Module.Requirements }}
-        No requirements.
+    {{- if not .Module.Requirements -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Requirements
+
+            No requirements.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "=" }} Requirements
+
         [cols="a,a",options="header,autowidth"]
         |===
         |Name |Version

--- a/internal/format/templates/asciidoc_table_resources.tmpl
+++ b/internal/format/templates/asciidoc_table_resources.tmpl
@@ -1,8 +1,13 @@
 {{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
-    {{ indent 0 "=" }} Resources
-    {{ if not .Module.Resources }}
-        No resources.
+    {{- if not .Module.Resources -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Resources
+
+            No resources.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "=" }} Resources
+
         [cols="a,a",options="header,autowidth"]
         |===
         |Name |Type

--- a/internal/format/templates/markdown_document_inputs.tmpl
+++ b/internal/format/templates/markdown_document_inputs.tmpl
@@ -1,9 +1,14 @@
 {{- if .Settings.ShowInputs -}}
     {{- if .Settings.ShowRequired -}}
-        {{ indent 0 "#" }} Required Inputs
-        {{ if not .Module.RequiredInputs }}
-            No required inputs.
+        {{- if not .Module.RequiredInputs -}}
+            {{- if not .Settings.HideEmpty -}}
+                {{- indent 0 "#" }} Required Inputs
+
+                No required inputs.
+            {{ end }}
         {{ else }}
+            {{- indent 0 "#" }} Required Inputs
+
             The following input variables are required:
             {{- range .Module.RequiredInputs }}
                 {{ printf "\n" }}
@@ -22,10 +27,15 @@
                 {{- end }}
             {{- end }}
         {{- end }}
-        {{ indent 0 "#" }} Optional Inputs
-        {{ if not .Module.OptionalInputs }}
-            No optional inputs.
+        {{- if not .Module.OptionalInputs -}}
+            {{- if not .Settings.HideEmpty -}}
+                {{- indent 0 "#" }} Optional Inputs
+
+                No optional inputs.
+            {{ end }}
         {{ else }}
+            {{- indent 0 "#" }} Optional Inputs
+
             The following input variables are optional (have default values):
             {{- range .Module.OptionalInputs }}
                 {{ printf "\n" }}
@@ -45,10 +55,15 @@
             {{- end }}
         {{ end }}
     {{ else -}}
-        {{ indent 0 "#" }} Inputs
-        {{ if not .Module.Inputs }}
-            No inputs.
+        {{- if not .Module.Inputs -}}
+            {{- if not .Settings.HideEmpty -}}
+                {{- indent 0 "#" }} Inputs
+
+                No inputs.
+            {{ end }}
         {{ else }}
+            {{- indent 0 "#" }} Inputs
+
             The following input variables are supported:
             {{- range .Module.Inputs }}
                 {{ printf "\n" }}

--- a/internal/format/templates/markdown_document_modules.tmpl
+++ b/internal/format/templates/markdown_document_modules.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowModuleCalls -}}
-    {{ indent 0 "#" }} Modules
-    {{ if not .Module.ModuleCalls }}
-        No modules.
+    {{- if not .Module.ModuleCalls -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Modules
+
+            No modules.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Modules
+
         The following Modules are called:
         {{- range .Module.ModuleCalls }}
 

--- a/internal/format/templates/markdown_document_outputs.tmpl
+++ b/internal/format/templates/markdown_document_outputs.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowOutputs -}}
-    {{ indent 0 "#" }} Outputs
-    {{ if not .Module.Outputs }}
-        No outputs.
+    {{- if not .Module.Outputs -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Outputs
+
+            No outputs.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Outputs
+
         The following outputs are exported:
         {{- range .Module.Outputs }}
 

--- a/internal/format/templates/markdown_document_providers.tmpl
+++ b/internal/format/templates/markdown_document_providers.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowProviders -}}
-    {{ indent 0 "#" }} Providers
-    {{ if not .Module.Providers }}
-        No providers.
+    {{- if not .Module.Providers -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Providers
+
+            No providers.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Providers
+
         The following providers are used by this module:
         {{- range .Module.Providers }}
             {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}

--- a/internal/format/templates/markdown_document_requirements.tmpl
+++ b/internal/format/templates/markdown_document_requirements.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowRequirements -}}
-    {{ indent 0 "#" }} Requirements
-    {{ if not .Module.Requirements }}
-        No requirements.
+    {{- if not .Module.Requirements -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Requirements
+
+            No requirements.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Requirements
+
         The following requirements are needed by this module:
         {{- range .Module.Requirements }}
             {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}

--- a/internal/format/templates/markdown_document_resources.tmpl
+++ b/internal/format/templates/markdown_document_resources.tmpl
@@ -1,8 +1,13 @@
 {{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
-    {{ indent 0 "#" }} Resources
-    {{ if not .Module.Resources }}
-        No resources.
+    {{- if not .Module.Resources -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Resources
+
+            No resources.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Resources
+
         The following resources are used by this module:
         {{ range .Module.Resources }}
             {{- $isResource := and $.Settings.ShowResources ( eq "resource" (printf "%s" .GetMode)) }}

--- a/internal/format/templates/markdown_table_inputs.tmpl
+++ b/internal/format/templates/markdown_table_inputs.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowInputs -}}
-    {{ indent 0 "#" }} Inputs
-    {{ if not .Module.Inputs }}
-        No inputs.
+    {{- if not .Module.Inputs -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Inputs
+
+            No inputs.
+        {{- end }}
     {{ else }}
+        {{- indent 0 "#" }} Inputs
+
         | Name | Description |
         {{- if .Settings.ShowType }} Type |{{ end }}
         {{- if .Settings.ShowDefault }} Default |{{ end }}

--- a/internal/format/templates/markdown_table_modules.tmpl
+++ b/internal/format/templates/markdown_table_modules.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowModuleCalls -}}
-    {{ indent 0 "#" }} Modules
-    {{ if not .Module.ModuleCalls }}
-        No modules.
+    {{- if not .Module.ModuleCalls -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Modules
+
+            No modules.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Modules
+
         | Name | Source | Version |
         |------|--------|---------|
         {{- range .Module.ModuleCalls }}

--- a/internal/format/templates/markdown_table_outputs.tmpl
+++ b/internal/format/templates/markdown_table_outputs.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowOutputs -}}
-    {{ indent 0 "#" }} Outputs
-    {{ if not .Module.Outputs }}
-        No outputs.
+    {{- if not .Module.Outputs -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Outputs
+
+            No outputs.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Outputs
+
         | Name | Description |{{ if .Settings.OutputValues }} Value |{{ if $.Settings.ShowSensitivity }} Sensitive |{{ end }}{{ end }}
         |------|-------------|{{ if .Settings.OutputValues }}-------|{{ if $.Settings.ShowSensitivity }}:---------:|{{ end }}{{ end }}
         {{- range .Module.Outputs }}

--- a/internal/format/templates/markdown_table_providers.tmpl
+++ b/internal/format/templates/markdown_table_providers.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowProviders -}}
-    {{ indent 0 "#" }} Providers
-    {{ if not .Module.Providers }}
-        No providers.
+    {{- if not .Module.Providers -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Providers
+
+            No providers.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Providers
+
         | Name | Version |
         |------|---------|
         {{- range .Module.Providers }}

--- a/internal/format/templates/markdown_table_requirements.tmpl
+++ b/internal/format/templates/markdown_table_requirements.tmpl
@@ -1,8 +1,13 @@
 {{- if .Settings.ShowRequirements -}}
-    {{ indent 0 "#" }} Requirements
-    {{ if not .Module.Requirements }}
-        No requirements.
+    {{- if not .Module.Requirements -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Requirements
+
+            No requirements.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Requirements
+
         | Name | Version |
         |------|---------|
         {{- range .Module.Requirements }}

--- a/internal/format/templates/markdown_table_resources.tmpl
+++ b/internal/format/templates/markdown_table_resources.tmpl
@@ -1,8 +1,13 @@
 {{- if or .Settings.ShowResources .Settings.ShowDataSources -}}
-    {{ indent 0 "#" }} Resources
-    {{ if not .Module.Resources }}
-        No resources.
+    {{- if not .Module.Resources -}}
+        {{- if not .Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Resources
+
+            No resources.
+        {{ end }}
     {{ else }}
+        {{- indent 0 "#" }} Resources
+
         | Name | Type |
         |------|------|
         {{- range .Module.Resources }}

--- a/internal/print/settings.go
+++ b/internal/print/settings.go
@@ -23,6 +23,12 @@ type Settings struct {
 	// scope: Markdown
 	EscapeCharacters bool
 
+	// HideEmpty hide empty sections
+	//
+	// default: false
+	// scope: Global
+	HideEmpty bool
+
 	// IndentLevel control the indentation of headers [available: 1, 2, 3, 4, 5]
 	//
 	// default: 2
@@ -142,6 +148,7 @@ type Settings struct {
 func DefaultSettings() *Settings {
 	return &Settings{
 		EscapeCharacters: true,
+		HideEmpty:        false,
 		IndentLevel:      2,
 		OutputValues:     false,
 		ShowAnchor:       true,
@@ -168,6 +175,7 @@ func DefaultSettings() *Settings {
 func (s *Settings) Convert() *printsdk.Settings {
 	return &printsdk.Settings{
 		EscapeCharacters: s.EscapeCharacters,
+		HideEmpty:        s.HideEmpty,
 		IndentLevel:      s.IndentLevel,
 		OutputValues:     s.OutputValues,
 		ShowColor:        s.ShowColor,

--- a/internal/print/settings.go
+++ b/internal/print/settings.go
@@ -26,7 +26,7 @@ type Settings struct {
 	// HideEmpty hide empty sections
 	//
 	// default: false
-	// scope: Global
+	// scope: Asciidoc, Markdown
 	HideEmpty bool
 
 	// IndentLevel control the indentation of headers [available: 1, 2, 3, 4, 5]

--- a/internal/testutil/settings.go
+++ b/internal/testutil/settings.go
@@ -43,6 +43,14 @@ func WithHTML(override ...print.Settings) print.Settings {
 	return apply(base, override...)
 }
 
+// WithHideEmpty appends HideEmpty to provided Settings.
+func WithHideEmpty(override ...print.Settings) print.Settings {
+	base := print.Settings{
+		HideEmpty: true,
+	}
+	return apply(base, override...)
+}
+
 func apply(base print.Settings, override ...print.Settings) print.Settings {
 	dest := base
 	for i := range override {


### PR DESCRIPTION
### Description of your changes

`--Hide-empty` flag hides sections that have no content. 

For example:
```console
❯ ./terraform-docs md .
## Requirements

No requirements.
❯ ./terraform-docs md --hide-empty=true .

```

Only works for the following commands:
* md
* md document
* md table
* asciidoc
* asciidoc document
* asciidoc table

Fixes: https://github.com/terraform-docs/terraform-docs/issues/541

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

* Manually checked that the --help flag outputs info about `--hide-empty` only for the following cases:
  * md --help
  * md document --help
  * md table --help
  * asciidoc --help
  * asciidoc document --help
  * asciidoc table --help
* Added unit tests for asciidoc and markdown
* Manually checked that it runs

[contribution process]: https://git.io/JtEzg
