### PR TITLE
docs: Fix typo in user-guide Examples

### DIFF
--- a/docs/user-guide/configuration/sections.md
+++ b/docs/user-guide/configuration/sections.md
@@ -54,7 +54,7 @@ sections:
 
 ## Examples
 
-Show only `providrs`, `inputs`, and `outputs`.
+Show only `providers`, `inputs`, and `outputs`.
 
 ```yaml
 sections:
@@ -64,7 +64,7 @@ sections:
     - outputs
 ```
 
-Show everything except `providrs`.
+Show everything except `providers`.
 
 ```yaml
 sections:


### PR DESCRIPTION
### Description of your changes
Replace 2 instances of providrs with providers, in docs/user-guide/configuration/sections.md
