### PR TITLE
optionally process comments from tf files as description

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ settings:
   html: true
   indent: 2
   lockfile: true
+  read-comments: true
   required: true
   sensitive: true
   type: true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,8 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.OutputValues.Enabled, "output-values", false, "inject output values into outputs (default false)")
 	cmd.PersistentFlags().StringVar(&config.OutputValues.From, "output-values-from", "", "inject output values from file into outputs (default \"\")")
 
+	cmd.PersistentFlags().BoolVar(&config.Settings.ReadComments, "read-comments", true, "use comments as description when description is empty")
+
 	// formatter subcommands
 	cmd.AddCommand(asciidoc.NewCommand(runtime, config))
 	cmd.AddCommand(json.NewCommand(runtime, config))

--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -40,6 +40,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --required                    show Required column or section (default true)

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -40,6 +40,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --required                    show Required column or section (default true)

--- a/docs/reference/asciidoc.md
+++ b/docs/reference/asciidoc.md
@@ -43,6 +43,7 @@ terraform-docs asciidoc [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -37,6 +37,7 @@ terraform-docs json [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -42,6 +42,7 @@ terraform-docs markdown document [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --required                    show Required column or section (default true)

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -42,6 +42,7 @@ terraform-docs markdown table [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --required                    show Required column or section (default true)

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -45,6 +45,7 @@ terraform-docs markdown [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/pretty.md
+++ b/docs/reference/pretty.md
@@ -37,6 +37,7 @@ terraform-docs pretty [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/terraform-docs.md
+++ b/docs/reference/terraform-docs.md
@@ -31,6 +31,7 @@ terraform-docs [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/tfvars-hcl.md
+++ b/docs/reference/tfvars-hcl.md
@@ -37,6 +37,7 @@ terraform-docs tfvars hcl [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/tfvars-json.md
+++ b/docs/reference/tfvars-json.md
@@ -36,6 +36,7 @@ terraform-docs tfvars json [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/tfvars.md
+++ b/docs/reference/tfvars.md
@@ -32,6 +32,7 @@ Generate terraform.tfvars of inputs.
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/toml.md
+++ b/docs/reference/toml.md
@@ -36,6 +36,7 @@ terraform-docs toml [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/xml.md
+++ b/docs/reference/xml.md
@@ -36,6 +36,7 @@ terraform-docs xml [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -36,6 +36,7 @@ terraform-docs yaml [PATH] [flags]
       --output-template string      output template (default "<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->")
       --output-values               inject output values into outputs (default false)
       --output-values-from string   inject output values from file into outputs (default "")
+      --read-comments               use comments as description when description is empty (default true)
       --recursive                   update submodules recursively (default false)
       --recursive-path string       submodules path to recursively update (default "modules")
       --show strings                show section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -107,6 +107,7 @@ settings:
   html: true
   indent: 2
   lockfile: true
+  read-comments: true
   required: true
   sensitive: true
   type: true

--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -27,6 +27,7 @@ settings:
   html: true
   indent: 2
   lockfile: true
+  read-comments: true
   required: true
   sensitive: true
   type: true
@@ -94,6 +95,13 @@ Indentation level of headings [available: 1, 2, 3, 4, 5].
 > scope: `global`
 
 Read `.terraform.lock.hcl` to extract exact version of providers.
+
+### read-comments
+
+> since: `v0.16.0`\
+> scope: `global`
+
+Use comments from `tf` files for "Description" column (for inputs and outputs) when description is empty
 
 ### required
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -40,15 +40,16 @@ var flagMappings = map[string]string{
 	"sort-by-required": "required",
 	"sort-by-type":     "type",
 
-	"anchor":      "settings.anchor",
-	"color":       "settings.color",
-	"default":     "settings.default",
-	"description": "settings.description",
-	"escape":      "settings.escape",
-	"indent":      "settings.indent",
-	"required":    "settings.required",
-	"sensitive":   "settings.sensitive",
-	"type":        "settings.type",
+	"anchor":        "settings.anchor",
+	"color":         "settings.color",
+	"default":       "settings.default",
+	"description":   "settings.description",
+	"escape":        "settings.escape",
+	"indent":        "settings.indent",
+	"read-comments": "settings.read-comments",
+	"required":      "settings.required",
+	"sensitive":     "settings.sensitive",
+	"type":          "settings.type",
 }
 
 // Config represents all the available config options that can be accessed and passed through CLI
@@ -376,34 +377,36 @@ func (s *sort) validate() error {
 }
 
 type settings struct {
-	Anchor      bool `mapstructure:"anchor"`
-	Color       bool `mapstructure:"color"`
-	Default     bool `mapstructure:"default"`
-	Description bool `mapstructure:"description"`
-	Escape      bool `mapstructure:"escape"`
-	HideEmpty   bool `mapstructure:"hide-empty"`
-	HTML        bool `mapstructure:"html"`
-	Indent      int  `mapstructure:"indent"`
-	LockFile    bool `mapstructure:"lockfile"`
-	Required    bool `mapstructure:"required"`
-	Sensitive   bool `mapstructure:"sensitive"`
-	Type        bool `mapstructure:"type"`
+	Anchor       bool `mapstructure:"anchor"`
+	Color        bool `mapstructure:"color"`
+	Default      bool `mapstructure:"default"`
+	Description  bool `mapstructure:"description"`
+	Escape       bool `mapstructure:"escape"`
+	HideEmpty    bool `mapstructure:"hide-empty"`
+	HTML         bool `mapstructure:"html"`
+	Indent       int  `mapstructure:"indent"`
+	LockFile     bool `mapstructure:"lockfile"`
+	ReadComments bool `mapstructure:"read-comments"`
+	Required     bool `mapstructure:"required"`
+	Sensitive    bool `mapstructure:"sensitive"`
+	Type         bool `mapstructure:"type"`
 }
 
 func defaultSettings() settings {
 	return settings{
-		Anchor:      true,
-		Color:       true,
-		Default:     true,
-		Description: false,
-		Escape:      true,
-		HideEmpty:   false,
-		HTML:        true,
-		Indent:      2,
-		LockFile:    true,
-		Required:    true,
-		Sensitive:   true,
-		Type:        true,
+		Anchor:       true,
+		Color:        true,
+		Default:      true,
+		Description:  false,
+		Escape:       true,
+		HideEmpty:    false,
+		HTML:         true,
+		Indent:       2,
+		LockFile:     true,
+		ReadComments: true,
+		Required:     true,
+		Sensitive:    true,
+		Type:         true,
 	}
 }
 
@@ -510,6 +513,9 @@ func (c *Config) extract() (*print.Settings, *terraform.Options) {
 	options.SortBy.Name = c.Sort.Enabled && c.Sort.By == sortName
 	options.SortBy.Required = c.Sort.Enabled && c.Sort.By == sortRequired
 	options.SortBy.Type = c.Sort.Enabled && c.Sort.By == sortType
+
+	// read comments
+	options.ReadComments = c.Settings.ReadComments
 
 	// settings
 	settings.EscapeCharacters = c.Settings.Escape

--- a/internal/terraform/module.go
+++ b/internal/terraform/module.go
@@ -148,7 +148,7 @@ func loadModuleItems(tfmodule *tfconfig.Module, options *Options) (*Module, erro
 		return nil, err
 	}
 
-	inputs, required, optional := loadInputs(tfmodule)
+	inputs, required, optional := loadInputs(tfmodule, options)
 	modulecalls := loadModulecalls(tfmodule)
 	outputs, err := loadOutputs(tfmodule, options)
 	if err != nil {
@@ -265,7 +265,7 @@ func loadSection(options *Options, file string, section string) (string, error) 
 	return strings.Join(sectionText, "\n"), nil
 }
 
-func loadInputs(tfmodule *tfconfig.Module) ([]*Input, []*Input, []*Input) {
+func loadInputs(tfmodule *tfconfig.Module, options *Options) ([]*Input, []*Input, []*Input) {
 	var inputs = make([]*Input, 0, len(tfmodule.Variables))
 	var required = make([]*Input, 0, len(tfmodule.Variables))
 	var optional = make([]*Input, 0, len(tfmodule.Variables))
@@ -273,7 +273,7 @@ func loadInputs(tfmodule *tfconfig.Module) ([]*Input, []*Input, []*Input) {
 	for _, input := range tfmodule.Variables {
 		// convert CRLF to LF early on (https://github.com/terraform-docs/terraform-docs/issues/305)
 		inputDescription := strings.ReplaceAll(input.Description, "\r\n", "\n")
-		if inputDescription == "" {
+		if inputDescription == "" && options.ReadComments {
 			inputDescription = loadComments(input.Pos.Filename, input.Pos.Line)
 		}
 
@@ -355,7 +355,7 @@ func loadOutputs(tfmodule *tfconfig.Module, options *Options) ([]*Output, error)
 	}
 	for _, o := range tfmodule.Outputs {
 		description := o.Description
-		if description == "" {
+		if description == "" && options.ReadComments {
 			description = loadComments(o.Pos.Filename, o.Pos.Line)
 		}
 		output := &Output{

--- a/internal/terraform/options.go
+++ b/internal/terraform/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	SortBy           *SortBy
 	OutputValues     bool
 	OutputValuesPath string
+	ReadComments     bool
 }
 
 // NewOptions returns new instance of Options
@@ -49,6 +50,7 @@ func NewOptions() *Options {
 		SortBy:           &SortBy{Name: false, Required: false, Type: false},
 		OutputValues:     false,
 		OutputValuesPath: "",
+		ReadComments:     true,
 	}
 }
 

--- a/internal/terraform/testdata/read-comments/variables.tf
+++ b/internal/terraform/testdata/read-comments/variables.tf
@@ -1,0 +1,9 @@
+// B description
+variable "B" {
+  default = "b"
+}
+
+// B description
+output "B" {
+  value = "b"
+}

--- a/scripts/docs/generate.go
+++ b/scripts/docs/generate.go
@@ -183,6 +183,7 @@ func example(ref *reference) error {
 		SortBy: &terraform.SortBy{
 			Name: true,
 		},
+		ReadComments: true,
 	}
 
 	formatter, err := format.Factory(ref.Name, settings)


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #552

This PR includes changes to optionally process comments from `.tf` files as description (when description is not provided in terraform inputs, outputs definition)

- Adds flag **`read-comments`** 

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested
- Added test `TestReadComments()`
- Tested with `make test`
- Tested manually 

> **Manual Test**
> - Create sample tf folder and file
> ```
> mkdir /tmp/test-tf
> cat <<EOF >> /tmp/test-tf/sample.tf
> # some comment
> variable "var1" {
> }
> 
> # some comment
> output "output-var1" {
>   value = null
> }
> EOF
> ```
> 
> - Tested with read-comments as false. Expected - description should be n/a (should not use comment (#some comment) as description)
> ```go
> ▶ go run main.go --read-comments=false --show=inputs,outputs markdown /tmp/test-tf
> ```
> **Result:**
> ## Inputs
> 
> | Name | Description | Type | Default | Required |
> |------|-------------|------|---------|:--------:|
> | <a name="input_var1"></a> [var1](#input\_var1) | n/a | `any` | n/a | yes |
> 
> ## Outputs
> 
> | Name | Description |
> |------|-------------|
> | <a name="output_output-var1"></a> [output-var1](#output\_output-var1) | n/a |
> 
> - Tested with read-comments as true. Expected - 'some comment' is used as description
> ```
> ▶ go run main.go --read-comments=true --show=inputs,outputs markdown /tmp/test-tf  
> ```
> **Result:**
> ## Inputs
> 
> | Name | Description | Type | Default | Required |
> |------|-------------|------|---------|:--------:|
> | <a name="input_var1"></a> [var1](#input\_var1) | some comment | `any` | n/a | yes |
> 
> ## Outputs
> 
> | Name | Description |
> |------|-------------|
> | <a name="output_output-var1"></a> [output-var1](#output\_output-var1) | some comment |
> - Cleanup
> ```
> $ rm -r /tmp/test-tf
> ```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg

**TBD**

- ~Config setting that maps to the new option added~ Added new config setting `read-comments`
- ~Tests when option is set to `false`. Currently few tests fail when option is set to `false`~ set default to true (for backwards compatibility). Added new test cases to test when set to `false` and `true`