### PR TITLE
add bin/ in installation with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ binary for your platform from "Assets" and place this into your `$PATH`:
 curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname)-amd64.tar.gz
 tar -xzf terraform-docs.tar.gz
 chmod +x terraform-docs
-mv terraform-docs /usr/local/terraform-docs
+mv terraform-docs /usr/local/bin/terraform-docs
 ```
 
 **NOTE:** Windows releases are in `ZIP` format.


### PR DESCRIPTION
Hi.

thanks for your work :muscle: 

### Description of your changes

Here is a fix on the installation process with curl to add a missing `bin/` in the final location of the binary.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [ ] All tests pass when I run `make test`.

### How has this code been tested

no test where done

[contribution process]: https://git.io/JtEzg
