### PR TITLE
fix: sort required format

### DIFF
--- a/docs/user-guide/configuration/sort.md
+++ b/docs/user-guide/configuration/sort.md
@@ -63,6 +63,5 @@ Sort by required (terraform-docs `< v0.13.0`):
 ```yaml
 sort:
   enabled: true
-  by:
-    - required
+  by: required
 ```


### PR DESCRIPTION
Signed-off-by: Rishang <rishangbhavsar22@gmail.com>

### Fixed to docs for `required` paramater in sort format
