### PR TITLE
Fix CI linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ endif
 .PHONY: golangci
 golangci:   ## Install golangci
 ifeq (, $(shell which golangci-lint))
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s  -- -b $(shell $(GO) env GOPATH)/bin $(GOLANGCI_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell $(GO) env GOPATH)/bin $(GOLANGCI_VERSION)
 endif
 
 .PHONY: tools


### PR DESCRIPTION
### Description of your changes

From [GA runs](https://github.com/terraform-docs/terraform-docs/runs/7399944852?check_suite_focus=true) in #621, I realised the linter has been off, since the DNS for https://install.goreleaser.com no longer exists.

Switched it to the one liner suggested by the official `golangci-lint` guide: https://golangci-lint.run/usage/install/#linux-and-windows. And it happens to support version tag there too: https://github.com/golangci/golangci-lint/blob/4e60e8a894f113c23492c074c187e9bec1479463/install.sh#L14-L16, therefore just went with it.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

Tested locally (darwin arm64) by removing my existing `golangci-lint` binary, and `make golangci`. Up to GA to test it out for real 😄.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
