### PR TITLE
Update alpine to 3.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN make build
 
 ################
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 COPY --from=builder /go/src/terraform-docs/bin/linux-amd64/terraform-docs /usr/local/bin/
 

--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -6,7 +6,7 @@
 # You may obtain a copy of the License at the LICENSE file in
 # the root directory of this source tree.
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 COPY terraform-docs /usr/local/bin/terraform-docs
 


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change upgrade the alpine base image used by terraform-docs from 3.16.0 to 3.16.1

Vulnerabilities flagged for alpine 3.16.0

```
terraform-docs:master (alpine 3.16.0)

Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 0)

┌──────────────┬────────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ busybox      │ CVE-2022-30065 │ HIGH     │ 1.35.0-r13        │ 1.35.0-r15    │ busybox: A use-after-free in Busybox's awk applet leads to │
│              │                │          │                   │               │ denial of service...                                       │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-30065                 │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2022-2097  │ HIGH     │ 1.1.1o-r0         │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes               │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                  │
├──────────────┤                │          │                   │               │                                                            │
│ libssl1.1    │                │          │                   │               │                                                            │
│              │                │          │                   │               │                                                            │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ ssl_client   │ CVE-2022-30065 │ HIGH     │ 1.35.0-r13        │ 1.35.0-r15    │ busybox: A use-after-free in Busybox's awk applet leads to │
│              │                │          │                   │               │ denial of service...                                       │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-30065                 │
└──────────────┴────────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```
terraform-docs:latestalpine (alpine 3.16.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

[contribution process]: https://git.io/JtEzg
