### PR TITLE
Fixed recursive flag stat error

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -259,7 +259,12 @@ func (r *Runtime) mergeConfig(v *viper.Viper) (*print.Config, error) {
 func (r *Runtime) findSubmodules() ([]module, error) {
 	dir := filepath.Join(r.rootDir, r.config.Recursive.Path)
 
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
+	if _, err := os.Stat(dir); err != nil {
+
+		if os.IsNotExist(err) {
+			return []module{}, nil
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
### Description of your changes

Changed the behaviour of 'findSubmodules' in 'internal/cli/run.go', by returning an empty module list if the folder is not found, this will allow the normal execution of terraform-docs using '--recursive' even if the 'modules' folder is not available. It fixes when the recursive flag is used on a project without a "modules" folder. 

It only returns an empty list if  'err' is a 'NotExist' error, other wise it keeps the same behaviour: returns the error code.

Fixes #654 

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

Tested in terraform projects with and without "modules" folder.

[contribution process]: https://git.io/JtEzg
