### PR TITLE
docs: update image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Sponsored by [Scalr - Terraform Automation & Collaboration Software](https://scalr.com/?utm_source=terraform-docs)
 
-<a href="https://www.scalr.com/?utm_source=terraform-docs" target="_blank"><img src="https://bit.ly/2T7Qm3U" alt="Scalr - Terraform Automation & Collaboration Software" width="175" height="40" /></a>
+<a href="https://www.scalr.com/?utm_source=terraform-docs" target="_blank"><img src="https://uploads-ssl.webflow.com/612d11332fb2f65fa3db1a2a/612d11332fb2f64794db1b5e_logo%2520copy-p-500.png" alt="Scalr - Terraform Automation & Collaboration Software" width="175" height="40" /></a>
 
 ## What is terraform-docs
 


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The bitly link for the image of the Scaler logo returns a 403. I'm not positive if it is supposed to be the logo but it seems like it. I just pulled the url of the logo in the top left corner of their website.

I also think it's weird that target="_blank" isn't working

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

It hasn't 😄 Just a README update

[contribution process]: https://git.io/JtEzg
