### PR TITLE
Render a data or resource block's "Description" attribute in the markdown table template

### DIFF
--- a/format/templates/markdown_table_resources.tmpl
+++ b/format/templates/markdown_table_resources.tmpl
@@ -8,14 +8,14 @@
     {{ else }}
         {{- indent 0 "#" }} Resources
 
-        | Name | Type |
-        |------|------|
+        | Name | Type | Comment |
+        |------|------|---------|
         {{- range .Module.Resources }}
             {{- $isResource := and $.Config.Sections.Resources ( eq "resource" (printf "%s" .GetMode)) }}
             {{- $isDataResource := and $.Config.Sections.DataSources ( eq "data source" (printf "%s" .GetMode)) }}
             {{- if or $isResource $isDataResource }}
                 {{- $fullspec := ternary .URL (printf "[%s](%s)" .Spec .URL) .Spec }}
-                | {{ $fullspec }} | {{ .GetMode }} |
+                | {{ $fullspec }} | {{ .GetMode }} | {{ .GetDescription }} |
             {{- end }}
         {{- end }}
     {{ end }}

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -50,6 +50,17 @@ func (r *Resource) GetMode() string {
 	}
 }
 
+
+// GetDescription returns the resource's description, or "N/A" if it's empty
+func (r *Resource) GetDescription() string {
+	switch r.Description {
+	case "":
+		return "N/A"
+	default:
+		return r.Description
+	}
+}
+
 // URL returns a best guess at the URL for resource documentation
 func (r *Resource) URL() string {
 	kind := ""

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -76,6 +76,43 @@ func TestResourceMode(t *testing.T) {
 	}
 }
 
+func TestResourceDescription(t *testing.T) {
+	tests := map[string]struct {
+		resource    Resource
+		expectValue string
+	}{
+		"Present": {
+			resource: Resource{
+				Type:           "private_key",
+				ProviderName:   "tls",
+				ProviderSource: "hashicorp/tls",
+				Mode:           "managed",
+				Version:        types.String("latest"),
+				Description:    "a description",
+			},
+			expectValue: "a description",
+		},
+		"Empty": {
+			resource: Resource{
+				Type:           "caller_identity",
+				ProviderName:   "aws",
+				ProviderSource: "hashicorp/aws",
+				Mode:           "data",
+				Version:        types.String("latest"),
+				Description:    "",
+			},
+			expectValue: "N/A",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(tt.expectValue, tt.resource.GetDescription())
+		})
+	}
+}
+
 func TestResourceURL(t *testing.T) {
 	tests := map[string]struct {
 		resource    Resource


### PR DESCRIPTION
Adds a "Comment" column to markdown tables for resources and data blocks.

Fixes #688

- [x] Read and followed terraform-docs' [contribution process].
- [ ] All tests pass when I run `make test`.


