### PR TITLE
Update container to Alpine 3.18.2 and Go 1.18.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # You may obtain a copy of the License at the LICENSE file in
 # the root directory of this source tree.
 
-FROM golang:1.18.4-alpine AS builder
+FROM golang:1.18.10-alpine AS builder
 
 RUN apk add --update --no-cache make
 

--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -6,7 +6,7 @@
 # You may obtain a copy of the License at the LICENSE file in
 # the root directory of this source tree.
 
-FROM alpine:3.16.1
+FROM alpine:3.18.2
 
 COPY terraform-docs /usr/local/bin/terraform-docs
 


### PR DESCRIPTION
### Description of your changes

This updates the container base images to a more recent version.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

* `docker build -t my-terraform-docs .`
* `docker run --rm my-terraform-docs --version`
