### PR TITLE
Add an Examples section to automatically pull in module examples

### DIFF
--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -19,6 +19,7 @@ footer-from: footer.md
 sections:
   show:
     - header
+    - examples
     - inputs
     - providers
     - modules
@@ -87,5 +88,5 @@ settings:
   indent: 4
   escape: false
   default: false
-  required: false
+  required: true
   type: true

--- a/examples/examples/exampleA/main.tf
+++ b/examples/examples/exampleA/main.tf
@@ -1,0 +1,17 @@
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}

--- a/format/asciidoc_document_test.go
+++ b/format/asciidoc_document_test.go
@@ -106,6 +106,11 @@ func TestAsciidocDocument(t *testing.T) {
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
 		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
+		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),
 		},

--- a/format/asciidoc_table_test.go
+++ b/format/asciidoc_table_test.go
@@ -106,6 +106,11 @@ func TestAsciidocTable(t *testing.T) {
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
 		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
+		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),
 		},

--- a/format/generator.go
+++ b/format/generator.go
@@ -87,6 +87,13 @@ func withResources(resources string) generateFunc {
 	}
 }
 
+// withExamples specifies how the generator should add Examples.
+func withExamples(examples string) generateFunc {
+	return func(g *generator) {
+		g.examples = examples
+	}
+}
+
 // withModule specifies how the generator should add Resources.
 func withModule(module *terraform.Module) generateFunc {
 	return func(g *generator) {
@@ -122,6 +129,7 @@ type generator struct {
 	providers    string
 	requirements string
 	resources    string
+	examples     string
 
 	config *print.Config
 	module *terraform.Module
@@ -176,6 +184,9 @@ func (g *generator) Requirements() string { return g.requirements }
 
 // Resources returns generted requirements section based on the underlying format.
 func (g *generator) Resources() string { return g.resources }
+
+// Module returns generated example section based on the underlying format.
+func (g *generator) Examples() string { return g.examples }
 
 // Module returns generted requirements section based on the underlying format.
 func (g *generator) Module() *terraform.Module { return g.module }
@@ -253,6 +264,7 @@ func (g *generator) forEach(render func(string) (string, error)) error {
 		"providers":    withProviders,
 		"requirements": withRequirements,
 		"resources":    withResources,
+		"examples":     withExamples,
 	}
 	for name, callback := range mappings {
 		result, err := render(name)

--- a/format/json_test.go
+++ b/format/json_test.go
@@ -62,6 +62,11 @@ func TestJson(t *testing.T) {
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
 		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
+		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),
 		},

--- a/format/markdown_document_test.go
+++ b/format/markdown_document_test.go
@@ -143,6 +143,11 @@ func TestMarkdownDocument(t *testing.T) {
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
 		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
+		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),
 		},

--- a/format/markdown_table_test.go
+++ b/format/markdown_table_test.go
@@ -51,7 +51,6 @@ func TestMarkdownTable(t *testing.T) {
 				c.HeaderFrom = "bad.tf"
 			}),
 		},
-
 		// Settings
 		"WithRequired": {
 			config: testutil.WithSections(
@@ -142,6 +141,11 @@ func TestMarkdownTable(t *testing.T) {
 		// Only section
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
+		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
 		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),

--- a/format/templates/asciidoc_document.tmpl
+++ b/format/templates/asciidoc_document.tmpl
@@ -1,4 +1,5 @@
 {{- template "header" . -}}
+{{- template "examples" . -}}
 {{- template "requirements" . -}}
 {{- template "providers" . -}}
 {{- template "modules" . -}}

--- a/format/templates/asciidoc_document_examples.tmpl
+++ b/format/templates/asciidoc_document_examples.tmpl
@@ -1,0 +1,22 @@
+{{- if .Config.Sections.Examples -}}
+    {{- if not .Module.Examples -}}
+        {{- if not .Config.Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Examples
+
+            No examples.
+        {{ end }}
+    {{ else }}
+        {{- indent 0 "=" }} Examples 
+    
+        {{$hideTitles := .Config.Examples.HideTitles}} 
+        {{- range .Module.Examples }}
+            {{- if not $hideTitles }}
+                {{ indent 1 "=" }} {{ .Name }}
+            {{- end }}
+            ```hcl
+            {{ .Content }}
+            ```
+
+        {{ end }}
+    {{ end }}
+{{ end -}}

--- a/format/templates/asciidoc_table.tmpl
+++ b/format/templates/asciidoc_table.tmpl
@@ -1,4 +1,5 @@
 {{- template "header" . -}}
+{{- template "examples" . -}}
 {{- template "requirements" . -}}
 {{- template "providers" . -}}
 {{- template "modules" . -}}

--- a/format/templates/asciidoc_table_examples.tmpl
+++ b/format/templates/asciidoc_table_examples.tmpl
@@ -1,0 +1,22 @@
+{{- if .Config.Sections.Examples -}}
+    {{- if not .Module.Examples -}}
+        {{- if not .Config.Settings.HideEmpty -}}
+            {{- indent 0 "=" }} Examples
+
+            No examples.
+        {{ end }}
+    {{ else }}
+        {{- indent 0 "=" }} Examples 
+
+        {{$hideTitles := .Config.Examples.HideTitles}} 
+        {{- range .Module.Examples }}
+            {{- if not $hideTitles }}
+                {{ indent 1 "=" }} {{ .Name }}
+            {{- end }}
+            ```hcl
+            {{ .Content }}
+            ```
+
+        {{ end }}
+    {{ end }}
+{{ end -}}

--- a/format/templates/markdown_document.tmpl
+++ b/format/templates/markdown_document.tmpl
@@ -1,4 +1,5 @@
 {{- template "header" . -}}
+{{- template "examples" . -}}
 {{- template "requirements" . -}}
 {{- template "providers" . -}}
 {{- template "modules" . -}}

--- a/format/templates/markdown_document_examples.tmpl
+++ b/format/templates/markdown_document_examples.tmpl
@@ -1,0 +1,23 @@
+{{- if .Config.Sections.Examples -}}
+    {{- if not .Module.Examples -}}
+        {{- if not .Config.Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Examples
+
+            No examples.
+        {{ end }}
+    {{ else }}
+        {{- indent 0 "#" }} Examples 
+    
+        {{$hideTitles := .Config.Examples.HideTitles}} 
+        {{- range .Module.Examples }}
+            {{- if not $hideTitles }}
+                {{ indent 1 "#" }} {{ .Name }}
+
+            {{ end }}
+            ```hcl
+            {{ .Content }}
+            ```
+
+        {{ end }}
+    {{ end }}
+{{ end -}}

--- a/format/templates/markdown_table.tmpl
+++ b/format/templates/markdown_table.tmpl
@@ -1,4 +1,5 @@
 {{- template "header" . -}}
+{{- template "examples" . -}}
 {{- template "requirements" . -}}
 {{- template "providers" . -}}
 {{- template "modules" . -}}

--- a/format/templates/markdown_table_examples.tmpl
+++ b/format/templates/markdown_table_examples.tmpl
@@ -1,0 +1,23 @@
+{{- if .Config.Sections.Examples -}}
+    {{- if not .Module.Examples -}}
+        {{- if not .Config.Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Examples
+
+            No examples.
+        {{ end }}
+    {{ else }}
+        {{- indent 0 "#" }} Examples 
+
+        {{$hideTitles := .Config.Examples.HideTitles}} 
+        {{- range .Module.Examples }}
+            {{- if not $hideTitles }}
+                {{ indent 1 "#" }} {{ .Name }}
+
+            {{ end }}
+            ```hcl
+            {{ .Content }}
+            ```
+
+        {{ end }}
+    {{ end }}
+{{ end -}}

--- a/format/templates/pretty.tmpl
+++ b/format/templates/pretty.tmpl
@@ -5,6 +5,17 @@
     {{- printf "\n\n" -}}
 {{ end -}}
 
+{{- if .Config.Sections.Examples -}}
+    {{- with .Module.Examples }}
+        {{- range . }}
+            {{- printf "example.%s" .Name | colorize "\033[36m" }}
+            {{ tostring .Content | colorize "\033[90m" }}
+            {{- printf "\n\n" -}}
+        {{ end -}}
+    {{ end -}}
+    {{- printf "\n" -}}
+{{ end -}}
+
 {{- if .Config.Sections.Requirements -}}
     {{- with .Module.Requirements }}
         {{- range . }}

--- a/format/testdata/asciidoc/document-Base.golden
+++ b/format/testdata/asciidoc/document-Base.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 == Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/asciidoc/document-IndentationOfFour.golden
+++ b/format/testdata/asciidoc/document-IndentationOfFour.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+==== Examples
+
+===== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ==== Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/asciidoc/document-OnlyExamples.golden
+++ b/format/testdata/asciidoc/document-OnlyExamples.golden
@@ -1,0 +1,22 @@
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```

--- a/format/testdata/asciidoc/document-WithAnchor.golden
+++ b/format/testdata/asciidoc/document-WithAnchor.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 == Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/asciidoc/document-WithRequired.golden
+++ b/format/testdata/asciidoc/document-WithRequired.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 == Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/asciidoc/table-Base.golden
+++ b/format/testdata/asciidoc/table-Base.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 == Requirements
 
 [cols="a,a",options="header,autowidth"]

--- a/format/testdata/asciidoc/table-IndentationOfFour.golden
+++ b/format/testdata/asciidoc/table-IndentationOfFour.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+==== Examples
+
+===== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ==== Requirements
 
 [cols="a,a",options="header,autowidth"]

--- a/format/testdata/asciidoc/table-OnlyExamples.golden
+++ b/format/testdata/asciidoc/table-OnlyExamples.golden
@@ -1,0 +1,22 @@
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```

--- a/format/testdata/asciidoc/table-WithAnchor.golden
+++ b/format/testdata/asciidoc/table-WithAnchor.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 == Requirements
 
 [cols="a,a",options="header,autowidth"]

--- a/format/testdata/asciidoc/table-WithRequired.golden
+++ b/format/testdata/asciidoc/table-WithRequired.golden
@@ -36,6 +36,29 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+== Examples
+
+=== exampleA
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 == Requirements
 
 [cols="a,a",options="header,autowidth"]

--- a/format/testdata/json/json-Base.golden
+++ b/format/testdata/json/json-Base.golden
@@ -1,6 +1,12 @@
 {
   "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "footer": "## This is an example of a footer\n\nIt looks exactly like a header, but is placed at the end of the document",
+  "examples": [
+    {
+      "name": "exampleA",
+      "content": "module full-example{\n    source = \"github.com/terraform-docs/terraform-docs//examples\"\n\n    input_with_underscores = \"input_any\"\n    list-2 = [\n        \"value_1\",\n        \"value_2\"\n    ]\n    map-2 = {\n        \"1\" = \"value\"\n        \"2\" = \"value_2\"\n    }\n    number-2 = 2\n    string-2 = \"2\"\n    string_no_default = \"string_value\"\n    unquoted = test\n}"
+    }
+  ],
   "inputs": [
     {
       "name": "unquoted",

--- a/format/testdata/json/json-Empty.golden
+++ b/format/testdata/json/json-Empty.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-EscapeCharacters.golden
+++ b/format/testdata/json/json-EscapeCharacters.golden
@@ -1,6 +1,12 @@
 {
   "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "footer": "## This is an example of a footer\n\nIt looks exactly like a header, but is placed at the end of the document",
+  "examples": [
+    {
+      "name": "exampleA",
+      "content": "module full-example{\n    source = \"github.com/terraform-docs/terraform-docs//examples\"\n\n    input_with_underscores = \"input_any\"\n    list-2 = [\n        \"value_1\",\n        \"value_2\"\n    ]\n    map-2 = {\n        \"1\" = \"value\"\n        \"2\" = \"value_2\"\n    }\n    number-2 = 2\n    string-2 = \"2\"\n    string_no_default = \"string_value\"\n    unquoted = test\n}"
+    }
+  ],
   "inputs": [
     {
       "name": "unquoted",

--- a/format/testdata/json/json-HideAll.golden
+++ b/format/testdata/json/json-HideAll.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-OnlyDataSources.golden
+++ b/format/testdata/json/json-OnlyDataSources.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-OnlyExamples.golden
+++ b/format/testdata/json/json-OnlyExamples.golden
@@ -1,0 +1,16 @@
+{
+  "header": "",
+  "footer": "",
+  "examples": [
+    {
+      "name": "exampleA",
+      "content": "module full-example{\n    source = \"github.com/terraform-docs/terraform-docs//examples\"\n\n    input_with_underscores = \"input_any\"\n    list-2 = [\n        \"value_1\",\n        \"value_2\"\n    ]\n    map-2 = {\n        \"1\" = \"value\"\n        \"2\" = \"value_2\"\n    }\n    number-2 = 2\n    string-2 = \"2\"\n    string_no_default = \"string_value\"\n    unquoted = test\n}"
+    }
+  ],
+  "inputs": [],
+  "modules": [],
+  "outputs": [],
+  "providers": [],
+  "requirements": [],
+  "resources": []
+}

--- a/format/testdata/json/json-OnlyFooter.golden
+++ b/format/testdata/json/json-OnlyFooter.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "## This is an example of a footer\n\nIt looks exactly like a header, but is placed at the end of the document",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-OnlyHeader.golden
+++ b/format/testdata/json/json-OnlyHeader.golden
@@ -1,6 +1,7 @@
 {
   "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-OnlyInputs.golden
+++ b/format/testdata/json/json-OnlyInputs.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [
     {
       "name": "unquoted",

--- a/format/testdata/json/json-OnlyModulecalls.golden
+++ b/format/testdata/json/json-OnlyModulecalls.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [
     {

--- a/format/testdata/json/json-OnlyOutputs.golden
+++ b/format/testdata/json/json-OnlyOutputs.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [

--- a/format/testdata/json/json-OnlyProviders.golden
+++ b/format/testdata/json/json-OnlyProviders.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-OnlyRequirements.golden
+++ b/format/testdata/json/json-OnlyRequirements.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-OnlyResources.golden
+++ b/format/testdata/json/json-OnlyResources.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [],

--- a/format/testdata/json/json-OutputValues.golden
+++ b/format/testdata/json/json-OutputValues.golden
@@ -1,6 +1,7 @@
 {
   "header": "",
   "footer": "",
+  "examples": [],
   "inputs": [],
   "modules": [],
   "outputs": [

--- a/format/testdata/markdown/document-Base.golden
+++ b/format/testdata/markdown/document-Base.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/markdown/document-EscapeCharacters.golden
+++ b/format/testdata/markdown/document-EscapeCharacters.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/markdown/document-IndentationOfFour.golden
+++ b/format/testdata/markdown/document-IndentationOfFour.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+#### Examples
+
+##### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 #### Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/markdown/document-OnlyExamples.golden
+++ b/format/testdata/markdown/document-OnlyExamples.golden
@@ -1,0 +1,23 @@
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```

--- a/format/testdata/markdown/document-WithAnchor.golden
+++ b/format/testdata/markdown/document-WithAnchor.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/markdown/document-WithRequired.golden
+++ b/format/testdata/markdown/document-WithRequired.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/markdown/document-WithoutHTML.golden
+++ b/format/testdata/markdown/document-WithoutHTML.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/markdown/document-WithoutHTMLWithAnchor.golden
+++ b/format/testdata/markdown/document-WithoutHTMLWithAnchor.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 The following requirements are needed by this module:

--- a/format/testdata/markdown/table-Base.golden
+++ b/format/testdata/markdown/table-Base.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/format/testdata/markdown/table-EscapeCharacters.golden
+++ b/format/testdata/markdown/table-EscapeCharacters.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/format/testdata/markdown/table-IndentationOfFour.golden
+++ b/format/testdata/markdown/table-IndentationOfFour.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+#### Examples
+
+##### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 #### Requirements
 
 | Name | Version |

--- a/format/testdata/markdown/table-OnlyExamples.golden
+++ b/format/testdata/markdown/table-OnlyExamples.golden
@@ -1,0 +1,23 @@
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```

--- a/format/testdata/markdown/table-WithAnchor.golden
+++ b/format/testdata/markdown/table-WithAnchor.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/format/testdata/markdown/table-WithRequired.golden
+++ b/format/testdata/markdown/table-WithRequired.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/format/testdata/markdown/table-WithoutHTML.golden
+++ b/format/testdata/markdown/table-WithoutHTML.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/format/testdata/markdown/table-WithoutHTMLWithAnchor.golden
+++ b/format/testdata/markdown/table-WithoutHTMLWithAnchor.golden
@@ -36,6 +36,30 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Examples
+
+### exampleA
+
+```hcl
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/format/testdata/pretty/pretty-Base.golden
+++ b/format/testdata/pretty/pretty-Base.golden
@@ -37,6 +37,26 @@ followed by another line of text.
 | Bar  | Bar description |
 
 
+example.exampleA
+module full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}
+
+
 requirement.terraform (>= 0.12)
 requirement.aws (>= 2.15.0)
 requirement.foo (>= 1.0)

--- a/format/testdata/pretty/pretty-WithColor.golden
+++ b/format/testdata/pretty/pretty-WithColor.golden
@@ -37,6 +37,26 @@ followed by another line of text.
 | Bar  | Bar description |[0m
 
 
+[36mexample.exampleA[0m
+[90mmodule full-example{
+    source = "github.com/terraform-docs/terraform-docs//examples"
+
+    input_with_underscores = "input_any"
+    list-2 = [
+        "value_1",
+        "value_2"
+    ]
+    map-2 = {
+        "1" = "value"
+        "2" = "value_2"
+    }
+    number-2 = 2
+    string-2 = "2"
+    string_no_default = "string_value"
+    unquoted = test
+}[0m
+
+
 [36mrequirement.terraform[0m (>= 0.12)
 [36mrequirement.aws[0m (>= 2.15.0)
 [36mrequirement.foo[0m (>= 1.0)

--- a/format/testdata/toml/toml-Base.golden
+++ b/format/testdata/toml/toml-Base.golden
@@ -1,6 +1,10 @@
 header = "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |"
 footer = "## This is an example of a footer\n\nIt looks exactly like a header, but is placed at the end of the document"
 
+[[examples]]
+  name = "exampleA"
+  content = "module full-example{\n    source = \"github.com/terraform-docs/terraform-docs//examples\"\n\n    input_with_underscores = \"input_any\"\n    list-2 = [\n        \"value_1\",\n        \"value_2\"\n    ]\n    map-2 = {\n        \"1\" = \"value\"\n        \"2\" = \"value_2\"\n    }\n    number-2 = 2\n    string-2 = \"2\"\n    string_no_default = \"string_value\"\n    unquoted = test\n}"
+
 [[inputs]]
   name = "unquoted"
   type = "any"

--- a/format/testdata/toml/toml-Empty.golden
+++ b/format/testdata/toml/toml-Empty.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-HideAll.golden
+++ b/format/testdata/toml/toml-HideAll.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-OnlyDataSources.golden
+++ b/format/testdata/toml/toml-OnlyDataSources.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-OnlyExamples.golden
+++ b/format/testdata/toml/toml-OnlyExamples.golden
@@ -1,0 +1,12 @@
+header = ""
+footer = ""
+inputs = []
+modules = []
+outputs = []
+providers = []
+requirements = []
+resources = []
+
+[[examples]]
+  name = "exampleA"
+  content = "module full-example{\n    source = \"github.com/terraform-docs/terraform-docs//examples\"\n\n    input_with_underscores = \"input_any\"\n    list-2 = [\n        \"value_1\",\n        \"value_2\"\n    ]\n    map-2 = {\n        \"1\" = \"value\"\n        \"2\" = \"value_2\"\n    }\n    number-2 = 2\n    string-2 = \"2\"\n    string_no_default = \"string_value\"\n    unquoted = test\n}"

--- a/format/testdata/toml/toml-OnlyFooter.golden
+++ b/format/testdata/toml/toml-OnlyFooter.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = "## This is an example of a footer\n\nIt looks exactly like a header, but is placed at the end of the document"
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-OnlyHeader.golden
+++ b/format/testdata/toml/toml-OnlyHeader.golden
@@ -1,5 +1,6 @@
 header = "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |"
 footer = ""
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-OnlyInputs.golden
+++ b/format/testdata/toml/toml-OnlyInputs.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 modules = []
 outputs = []
 providers = []

--- a/format/testdata/toml/toml-OnlyModulecalls.golden
+++ b/format/testdata/toml/toml-OnlyModulecalls.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 outputs = []
 providers = []

--- a/format/testdata/toml/toml-OnlyOutputs.golden
+++ b/format/testdata/toml/toml-OnlyOutputs.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 providers = []

--- a/format/testdata/toml/toml-OnlyProviders.golden
+++ b/format/testdata/toml/toml-OnlyProviders.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-OnlyRequirements.golden
+++ b/format/testdata/toml/toml-OnlyRequirements.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-OnlyResources.golden
+++ b/format/testdata/toml/toml-OnlyResources.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 outputs = []

--- a/format/testdata/toml/toml-OutputValues.golden
+++ b/format/testdata/toml/toml-OutputValues.golden
@@ -1,5 +1,6 @@
 header = ""
 footer = ""
+examples = []
 inputs = []
 modules = []
 providers = []

--- a/format/testdata/xml/xml-Base.golden
+++ b/format/testdata/xml/xml-Base.golden
@@ -1,6 +1,12 @@
 <module>
   <header>Usage:&#xA;&#xA;Example of &#39;foo_bar&#39; module in `foo_bar.tf`.&#xA;&#xA;- list item 1&#xA;- list item 2&#xA;&#xA;Even inline **formatting** in _here_ is possible.&#xA;and some [link](https://domain.com/)&#xA;&#xA;* list item 3&#xA;* list item 4&#xA;&#xA;```hcl&#xA;module &#34;foo_bar&#34; {&#xA;  source = &#34;github.com/foo/bar&#34;&#xA;&#xA;  id   = &#34;1234567890&#34;&#xA;  name = &#34;baz&#34;&#xA;&#xA;  zones = [&#34;us-east-1&#34;, &#34;us-west-1&#34;]&#xA;&#xA;  tags = {&#xA;    Name         = &#34;baz&#34;&#xA;    Created-By   = &#34;first.last@email.com&#34;&#xA;    Date-Created = &#34;20180101&#34;&#xA;  }&#xA;}&#xA;```&#xA;&#xA;Here is some trailing text after code block,&#xA;followed by another line of text.&#xA;&#xA;| Name | Description     |&#xA;|------|-----------------|&#xA;| Foo  | Foo description |&#xA;| Bar  | Bar description |</header>
   <footer>## This is an example of a footer&#xA;&#xA;It looks exactly like a header, but is placed at the end of the document</footer>
+  <examples>
+    <example>
+      <name>exampleA</name>
+      <content>module full-example{&#xA;    source = &#34;github.com/terraform-docs/terraform-docs//examples&#34;&#xA;&#xA;    input_with_underscores = &#34;input_any&#34;&#xA;    list-2 = [&#xA;        &#34;value_1&#34;,&#xA;        &#34;value_2&#34;&#xA;    ]&#xA;    map-2 = {&#xA;        &#34;1&#34; = &#34;value&#34;&#xA;        &#34;2&#34; = &#34;value_2&#34;&#xA;    }&#xA;    number-2 = 2&#xA;    string-2 = &#34;2&#34;&#xA;    string_no_default = &#34;string_value&#34;&#xA;    unquoted = test&#xA;}</content>
+    </example>
+  </examples>
   <inputs>
     <input>
       <name>unquoted</name>

--- a/format/testdata/xml/xml-Empty.golden
+++ b/format/testdata/xml/xml-Empty.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-HideAll.golden
+++ b/format/testdata/xml/xml-HideAll.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-OnlyDataSources.golden
+++ b/format/testdata/xml/xml-OnlyDataSources.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-OnlyExamples.golden
+++ b/format/testdata/xml/xml-OnlyExamples.golden
@@ -1,0 +1,16 @@
+<module>
+  <header></header>
+  <footer></footer>
+  <examples>
+    <example>
+      <name>exampleA</name>
+      <content>module full-example{&#xA;    source = &#34;github.com/terraform-docs/terraform-docs//examples&#34;&#xA;&#xA;    input_with_underscores = &#34;input_any&#34;&#xA;    list-2 = [&#xA;        &#34;value_1&#34;,&#xA;        &#34;value_2&#34;&#xA;    ]&#xA;    map-2 = {&#xA;        &#34;1&#34; = &#34;value&#34;&#xA;        &#34;2&#34; = &#34;value_2&#34;&#xA;    }&#xA;    number-2 = 2&#xA;    string-2 = &#34;2&#34;&#xA;    string_no_default = &#34;string_value&#34;&#xA;    unquoted = test&#xA;}</content>
+    </example>
+  </examples>
+  <inputs></inputs>
+  <modules></modules>
+  <outputs></outputs>
+  <providers></providers>
+  <requirements></requirements>
+  <resources></resources>
+</module>

--- a/format/testdata/xml/xml-OnlyFooter.golden
+++ b/format/testdata/xml/xml-OnlyFooter.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer>## This is an example of a footer&#xA;&#xA;It looks exactly like a header, but is placed at the end of the document</footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-OnlyHeader.golden
+++ b/format/testdata/xml/xml-OnlyHeader.golden
@@ -1,6 +1,7 @@
 <module>
   <header>Usage:&#xA;&#xA;Example of &#39;foo_bar&#39; module in `foo_bar.tf`.&#xA;&#xA;- list item 1&#xA;- list item 2&#xA;&#xA;Even inline **formatting** in _here_ is possible.&#xA;and some [link](https://domain.com/)&#xA;&#xA;* list item 3&#xA;* list item 4&#xA;&#xA;```hcl&#xA;module &#34;foo_bar&#34; {&#xA;  source = &#34;github.com/foo/bar&#34;&#xA;&#xA;  id   = &#34;1234567890&#34;&#xA;  name = &#34;baz&#34;&#xA;&#xA;  zones = [&#34;us-east-1&#34;, &#34;us-west-1&#34;]&#xA;&#xA;  tags = {&#xA;    Name         = &#34;baz&#34;&#xA;    Created-By   = &#34;first.last@email.com&#34;&#xA;    Date-Created = &#34;20180101&#34;&#xA;  }&#xA;}&#xA;```&#xA;&#xA;Here is some trailing text after code block,&#xA;followed by another line of text.&#xA;&#xA;| Name | Description     |&#xA;|------|-----------------|&#xA;| Foo  | Foo description |&#xA;| Bar  | Bar description |</header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-OnlyInputs.golden
+++ b/format/testdata/xml/xml-OnlyInputs.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs>
     <input>
       <name>unquoted</name>

--- a/format/testdata/xml/xml-OnlyModulecalls.golden
+++ b/format/testdata/xml/xml-OnlyModulecalls.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules>
     <module>

--- a/format/testdata/xml/xml-OnlyOutputs.golden
+++ b/format/testdata/xml/xml-OnlyOutputs.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs>

--- a/format/testdata/xml/xml-OnlyProviders.golden
+++ b/format/testdata/xml/xml-OnlyProviders.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-OnlyRequirements.golden
+++ b/format/testdata/xml/xml-OnlyRequirements.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-OnlyResources.golden
+++ b/format/testdata/xml/xml-OnlyResources.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs></outputs>

--- a/format/testdata/xml/xml-OutputValues.golden
+++ b/format/testdata/xml/xml-OutputValues.golden
@@ -1,6 +1,7 @@
 <module>
   <header></header>
   <footer></footer>
+  <examples></examples>
   <inputs></inputs>
   <modules></modules>
   <outputs>

--- a/format/testdata/yaml/yaml-Base.golden
+++ b/format/testdata/yaml/yaml-Base.golden
@@ -40,6 +40,26 @@ footer: |-
   ## This is an example of a footer
 
   It looks exactly like a header, but is placed at the end of the document
+examples:
+  - name: exampleA
+    content: |-
+      module full-example{
+          source = "github.com/terraform-docs/terraform-docs//examples"
+
+          input_with_underscores = "input_any"
+          list-2 = [
+              "value_1",
+              "value_2"
+          ]
+          map-2 = {
+              "1" = "value"
+              "2" = "value_2"
+          }
+          number-2 = 2
+          string-2 = "2"
+          string_no_default = "string_value"
+          unquoted = test
+      }
 inputs:
   - name: unquoted
     type: any

--- a/format/testdata/yaml/yaml-Empty.golden
+++ b/format/testdata/yaml/yaml-Empty.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-HideAll.golden
+++ b/format/testdata/yaml/yaml-HideAll.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-OnlyDataSources.golden
+++ b/format/testdata/yaml/yaml-OnlyDataSources.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-OnlyExamples.golden
+++ b/format/testdata/yaml/yaml-OnlyExamples.golden
@@ -1,0 +1,28 @@
+header: ""
+footer: ""
+examples:
+  - name: exampleA
+    content: |-
+      module full-example{
+          source = "github.com/terraform-docs/terraform-docs//examples"
+
+          input_with_underscores = "input_any"
+          list-2 = [
+              "value_1",
+              "value_2"
+          ]
+          map-2 = {
+              "1" = "value"
+              "2" = "value_2"
+          }
+          number-2 = 2
+          string-2 = "2"
+          string_no_default = "string_value"
+          unquoted = test
+      }
+inputs: []
+modules: []
+outputs: []
+providers: []
+requirements: []
+resources: []

--- a/format/testdata/yaml/yaml-OnlyFooter.golden
+++ b/format/testdata/yaml/yaml-OnlyFooter.golden
@@ -3,6 +3,7 @@ footer: |-
   ## This is an example of a footer
 
   It looks exactly like a header, but is placed at the end of the document
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-OnlyHeader.golden
+++ b/format/testdata/yaml/yaml-OnlyHeader.golden
@@ -37,6 +37,7 @@ header: |-
   | Foo  | Foo description |
   | Bar  | Bar description |
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-OnlyInputs.golden
+++ b/format/testdata/yaml/yaml-OnlyInputs.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs:
   - name: unquoted
     type: any

--- a/format/testdata/yaml/yaml-OnlyModulecalls.golden
+++ b/format/testdata/yaml/yaml-OnlyModulecalls.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules:
   - name: bar

--- a/format/testdata/yaml/yaml-OnlyOutputs.golden
+++ b/format/testdata/yaml/yaml-OnlyOutputs.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs:

--- a/format/testdata/yaml/yaml-OnlyProviders.golden
+++ b/format/testdata/yaml/yaml-OnlyProviders.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-OnlyRequirements.golden
+++ b/format/testdata/yaml/yaml-OnlyRequirements.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-OnlyResources.golden
+++ b/format/testdata/yaml/yaml-OnlyResources.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs: []

--- a/format/testdata/yaml/yaml-OutputValues.golden
+++ b/format/testdata/yaml/yaml-OutputValues.golden
@@ -1,5 +1,6 @@
 header: ""
 footer: ""
+examples: []
 inputs: []
 modules: []
 outputs:

--- a/format/toml_test.go
+++ b/format/toml_test.go
@@ -55,6 +55,11 @@ func TestToml(t *testing.T) {
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
 		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
+		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),
 		},

--- a/format/util.go
+++ b/format/util.go
@@ -108,6 +108,7 @@ func copySections(config *print.Config, src *terraform.Module) *terraform.Module
 	dest := &terraform.Module{
 		Header:       "",
 		Footer:       "",
+		Examples:     make([]*terraform.Example, 0),
 		Inputs:       make([]*terraform.Input, 0),
 		ModuleCalls:  make([]*terraform.ModuleCall, 0),
 		Outputs:      make([]*terraform.Output, 0),
@@ -121,6 +122,9 @@ func copySections(config *print.Config, src *terraform.Module) *terraform.Module
 	}
 	if config.Sections.Footer {
 		dest.Footer = src.Footer
+	}
+	if config.Sections.Examples {
+		dest.Examples = src.Examples
 	}
 	if config.Sections.Inputs {
 		dest.Inputs = src.Inputs

--- a/format/xml_test.go
+++ b/format/xml_test.go
@@ -55,6 +55,11 @@ func TestXml(t *testing.T) {
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
 		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
+		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),
 		},

--- a/format/yaml_test.go
+++ b/format/yaml_test.go
@@ -55,6 +55,11 @@ func TestYaml(t *testing.T) {
 		"OnlyDataSources": {
 			config: testutil.With(func(c *print.Config) { c.Sections.DataSources = true }),
 		},
+		"OnlyExamples": {
+			config: testutil.With(func(c *print.Config) {
+				c.Sections.Examples = true
+			}),
+		},
 		"OnlyHeader": {
 			config: testutil.With(func(c *print.Config) { c.Sections.Header = true }),
 		},

--- a/internal/testutil/config.go
+++ b/internal/testutil/config.go
@@ -49,17 +49,19 @@ func With(fn func(*print.Config)) print.Config {
 	return base
 }
 
-// WithSections shows all sections (including footer) to provided print.Config.
+// WithSections shows all sections (including footer & examples) to provided print.Config.
 func WithSections(override ...print.Config) print.Config {
 	base := baseSections()
 
 	base.Sections.Footer = true
 	base.FooterFrom = "footer.md"
 
+	base.Sections.Examples = true
+
 	return apply(base, override...)
 }
 
-// WithDefaultSections shows default sections (everything except footer) to provided print.Config.
+// WithDefaultSections shows default sections (everything except footer & examples) to provided print.Config.
 func WithDefaultSections(override ...print.Config) print.Config {
 	base := baseSections()
 

--- a/terraform/example.go
+++ b/terraform/example.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2021 The terraform-docs Authors.
+
+Licensed under the MIT license (the "License"); you may not
+use this file except in compliance with the License.
+
+You may obtain a copy of the License at the LICENSE file in
+the root directory of this source tree.
+*/
+
+package terraform
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"unicode"
+
+	"github.com/terraform-docs/terraform-docs/internal/types"
+	"github.com/terraform-docs/terraform-docs/print"
+)
+
+// Requirement represents a requirement for Terraform module.
+type Example struct {
+	Name    string       `json:"name" toml:"name" xml:"name" yaml:"name"`
+	Content types.String `json:"content" toml:"content" xml:"content" yaml:"content"`
+}
+
+// Creating a struct that handles the actual getting of example content
+// and allowing load.go to handle the logic of loading that into a
+// module object
+type ExampleLoader struct {
+	config   *print.Config
+	examples []*Example
+}
+
+func NewExampleLoader(config *print.Config) *ExampleLoader {
+	loader := &ExampleLoader{
+		config,
+		[]*Example{},
+	}
+	return loader
+}
+
+func (loader *ExampleLoader) SearchFolder() error {
+	path := filepath.Join(loader.config.ModuleRoot, loader.config.ExamplesFrom)
+	if !FileExists(path) {
+		return fmt.Errorf("specified examples folder '%s' does not exist", path)
+	}
+	possibleExamples := GetChildFolders(path)
+	for _, f := range possibleExamples {
+		if HasChildMainTf(f) {
+			maintfPath := filepath.Join(f, "main.tf")
+			name := filepath.Base(f)
+			if len(loader.config.Examples.Include) > 0 && !contains(loader.config.Examples.Include, name) {
+				continue
+			}
+			if len(loader.config.Examples.Exclude) > 0 && contains(loader.config.Examples.Exclude, name) {
+				continue
+			}
+			buf, err := os.ReadFile(maintfPath)
+			if err != nil {
+				return err
+			}
+			content := string(buf)
+			if !isOnlyWhitespace(content) {
+				loader.examples = append(loader.examples, &Example{name, types.String(content)})
+				if len(loader.examples) == loader.config.Examples.Limit { // if limit is reached,
+					return nil
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (loader *ExampleLoader) GetFile(relativePath string) error {
+	path := filepath.Join(loader.config.ModuleRoot, relativePath)
+	if !FileExists(path) {
+		return fmt.Errorf("specified example file '%s' does not exist", path)
+	}
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	content := string(buf)
+	if !isOnlyWhitespace(content) {
+		exampleName := filepath.Base(filepath.Dir(path))
+		loader.examples = append(loader.examples, &Example{exampleName, types.String(content)})
+	}
+	return nil
+}
+
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}
+
+func GetChildFolders(path string) []string {
+	var childFolders []string
+	filepath.WalkDir(path, func(path string, file fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if file.IsDir() {
+			childFolders = append(childFolders, path)
+		}
+		return nil
+	})
+
+	return childFolders[1:]
+}
+
+func HasChildMainTf(path string) bool {
+	var childFiles []string
+	filepath.WalkDir(path, func(path string, file fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !file.IsDir() {
+			childFiles = append(childFiles, path)
+		}
+		return nil
+	})
+
+	for _, fileName := range childFiles {
+		if filepath.Base(fileName) == "main.tf" {
+			return true
+		}
+	}
+	return false
+}
+
+func isOnlyWhitespace(input string) bool {
+	for _, c := range input {
+		if !unicode.IsSpace(c) { //if
+			return false
+		}
+	}
+	return true
+}
+
+func contains(set []string, str string) bool {
+	for _, i := range set {
+		if i == str {
+			return true
+		}
+	}
+	return false
+}

--- a/terraform/example_test.go
+++ b/terraform/example_test.go
@@ -1,0 +1,384 @@
+package terraform
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/terraform-docs/terraform-docs/print"
+)
+
+func TestExampleFileExists(t *testing.T) {
+	pathToTempFolder := ""
+	tempFolderPattern := "exmplFileExstChck"
+
+	dir, _ := ioutil.TempDir(pathToTempFolder, tempFolderPattern)
+	tempFile, _ := os.CreateTemp(dir, "test.tf")
+	defer os.RemoveAll(dir)
+
+	tests := []struct {
+		name          string
+		pathToTest    string
+		expectedValue bool
+	}{
+		{
+			name:          "checkForExistingFolder",
+			pathToTest:    dir,
+			expectedValue: true,
+		},
+		{
+			name:          "checkForNonExistingFolder",
+			pathToTest:    filepath.Join(dir, "Non-existentFolder"),
+			expectedValue: false,
+		},
+		{
+			name:          "checkForExistingFile",
+			pathToTest:    tempFile.Name(),
+			expectedValue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tt.expectedValue, FileExists(tt.pathToTest))
+		})
+	}
+
+	assert.Equal(t, true, FileExists(dir))
+}
+
+func TestExampleGetChildFolders(t *testing.T) {
+	//var expectedValue []string
+	pathToTempFolder := ""
+	tempFolderPattern := "exampleGetChildFolderCheck"
+
+	checkFor2ChildFoldersDir, _ := os.MkdirTemp(pathToTempFolder, tempFolderPattern)
+	checkFor2ChildFoldersChildDir1, _ := os.MkdirTemp(checkFor2ChildFoldersDir, "testDir1")
+	checkFor2ChildFoldersChildDir2, _ := os.MkdirTemp(checkFor2ChildFoldersDir, "testDir2")
+	defer os.RemoveAll(checkFor2ChildFoldersDir)
+
+	checkForNonExistingChildFoldersDir, _ := os.MkdirTemp(pathToTempFolder, tempFolderPattern)
+	defer os.RemoveAll(checkForNonExistingChildFoldersDir)
+
+	checkFor1ChildFolderWithFilesDir, _ := os.MkdirTemp(pathToTempFolder, tempFolderPattern)
+	checkFor1ChildFolderWithFilesChildDir1, _ := os.MkdirTemp(checkFor1ChildFolderWithFilesDir, "testDir1")
+	os.CreateTemp(checkFor1ChildFolderWithFilesDir, "testFile1")
+	defer os.RemoveAll(checkFor1ChildFolderWithFilesDir)
+
+	tests := []struct {
+		name          string
+		pathToTest    string
+		expectedValue []string
+	}{
+		{
+			name:          "checkFor2ChildFolders",
+			pathToTest:    checkFor2ChildFoldersDir,
+			expectedValue: []string{checkFor2ChildFoldersChildDir1, checkFor2ChildFoldersChildDir2},
+		},
+		{
+			name:          "checkForNonExistingChildFolders",
+			pathToTest:    checkForNonExistingChildFoldersDir,
+			expectedValue: []string{},
+		},
+		{
+			name:          "checkFor1ChildFolderWithFiles",
+			pathToTest:    checkFor1ChildFolderWithFilesDir,
+			expectedValue: []string{checkFor1ChildFolderWithFilesChildDir1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tt.expectedValue, GetChildFolders(tt.pathToTest))
+		})
+	}
+}
+
+func TestExampleHasChildMainTf(t *testing.T) {
+	pathToTempFolder := ""
+	tempFolderPattern := "exampleHasChildMainTfCheck"
+
+	checkForNoChildFilesDir, _ := os.MkdirTemp(pathToTempFolder, tempFolderPattern)
+	defer os.RemoveAll(checkForNoChildFilesDir)
+
+	checkForMainTfDir, _ := os.MkdirTemp(pathToTempFolder, tempFolderPattern)
+	os.Create(filepath.Join(checkForMainTfDir, "main.tf"))
+	defer os.RemoveAll(checkForMainTfDir)
+
+	checkForNoMainTfDir, _ := os.MkdirTemp(pathToTempFolder, tempFolderPattern)
+	os.Create(filepath.Join(checkForNoMainTfDir, "notmain.tf"))
+	os.Create(filepath.Join(checkForNoMainTfDir, "alsonotmain.tf"))
+	defer os.RemoveAll(checkForNoMainTfDir)
+
+	tests := []struct {
+		name          string
+		pathToTest    string
+		expectedValue bool
+	}{
+		{
+			name:          "checkForNoChildFiles",
+			pathToTest:    checkForNoChildFilesDir,
+			expectedValue: false,
+		},
+		{
+			name:          "checkForMainTf",
+			pathToTest:    checkForMainTfDir,
+			expectedValue: true,
+		},
+		{
+			name:          "checkForNoMainTf",
+			pathToTest:    checkForNoMainTfDir,
+			expectedValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tt.expectedValue, HasChildMainTf(tt.pathToTest))
+		})
+	}
+
+}
+
+func TestIsOnlyWhitespace(t *testing.T) {
+	//var loader ExampleLoader
+	tests := []struct {
+		name          string
+		stringToTest  string
+		expectedValue bool
+	}{
+		{
+			name:          "checkForOnlySpaces",
+			stringToTest:  "  ",
+			expectedValue: true,
+		},
+		{
+			name:          "checkForSpacesAndNewLine",
+			stringToTest:  "  \n ",
+			expectedValue: true,
+		},
+		{
+			name:          "checkForActualContent",
+			stringToTest:  "Real Text Here",
+			expectedValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tt.expectedValue, isOnlyWhitespace(tt.stringToTest))
+		})
+	}
+}
+
+func TestExampleLoader_SearchFolder(t *testing.T) {
+	basePath := ""
+	tempFolderPattern := "ExampleLoaderSearchFolderTests"
+	// Create the ExampleLoader and perform the search
+	loader := ExampleLoader{
+		config:   print.DefaultConfig(),
+		examples: nil, // Initialize with an empty slice
+	}
+
+	CheckFolderWithExampleDir, _ := os.MkdirTemp(basePath, tempFolderPattern)
+	ExampleFolder, _ := os.MkdirTemp(CheckFolderWithExampleDir, tempFolderPattern)
+	os.WriteFile(filepath.Join(ExampleFolder, "main.tf"), []byte("File Content"), 0777)
+	defer os.RemoveAll(CheckFolderWithExampleDir)
+
+	CheckFolderWithBlankExampleDir, _ := os.MkdirTemp(basePath, tempFolderPattern)
+	BlankExampleFolder, _ := os.MkdirTemp(CheckFolderWithBlankExampleDir, tempFolderPattern)
+	os.Create(filepath.Join(BlankExampleFolder, "main.tf"))
+	defer os.RemoveAll(CheckFolderWithBlankExampleDir)
+
+	CheckFolderWithoutMaintfDir, _ := os.MkdirTemp(basePath, tempFolderPattern)
+	os.MkdirTemp(CheckFolderWithoutMaintfDir, tempFolderPattern)
+	defer os.RemoveAll(CheckFolderWithoutMaintfDir)
+
+	tests := []struct {
+		name             string
+		exampleFolder    string
+		expectedError    bool
+		expectedExamples int
+	}{
+		{
+			name:             "CheckFolderWithExample",
+			exampleFolder:    CheckFolderWithExampleDir,
+			expectedError:    false,
+			expectedExamples: 1,
+		},
+		{
+			name:             "CheckFolderWithBlankExample",
+			exampleFolder:    CheckFolderWithBlankExampleDir,
+			expectedError:    false,
+			expectedExamples: 0, //If main.tf is blank, it should be ignored
+		},
+		{
+			name:             "Non-existing folder",
+			exampleFolder:    "non_existing_folder",
+			expectedError:    true,
+			expectedExamples: 0,
+		},
+		{
+			name:             "Folder without main.tf",
+			exampleFolder:    CheckFolderWithoutMaintfDir,
+			expectedError:    false,
+			expectedExamples: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			loader.config.ExamplesFrom = tt.exampleFolder
+			err := loader.SearchFolder()
+
+			if tt.expectedError && err == nil {
+				t.Error("Expected an error, but got nil")
+			}
+
+			if !tt.expectedError && err != nil {
+				t.Errorf("Expected no error, but got: %s", err)
+			}
+
+			assert.Equal(tt.expectedExamples, len(loader.examples))
+			loader.examples = nil
+		})
+	}
+}
+
+func TestExampleLoader_SearchFolderFilters(t *testing.T) {
+	basePath := ""
+	tempFolderPattern := "ExampleLoaderSearchFolderTests"
+	// Create the ExampleLoader and perform the search
+	loader := ExampleLoader{
+		config:   print.DefaultConfig(),
+		examples: nil, // Initialize with an empty slice
+	}
+
+	CheckFolderWithExampleDir, _ := os.MkdirTemp(basePath, tempFolderPattern)
+	ExampleFolder, _ := os.MkdirTemp(CheckFolderWithExampleDir, tempFolderPattern)
+	exampleFilepath := filepath.Join(ExampleFolder, "main.tf")
+	os.WriteFile(exampleFilepath, []byte("File Content"), 0777)
+	defer os.RemoveAll(CheckFolderWithExampleDir)
+
+	ExampleName := filepath.Base(ExampleFolder)
+
+	tests := []struct {
+		name             string
+		exampleFolder    string
+		included         []string
+		excluded         []string
+		expectedExamples int
+	}{
+		{
+			name:             "CheckFolderWithExample",
+			exampleFolder:    CheckFolderWithExampleDir,
+			included:         nil,
+			excluded:         nil,
+			expectedExamples: 1,
+		},
+		{
+			name:             "CheckFolderWithIncludedExample",
+			exampleFolder:    CheckFolderWithExampleDir,
+			included:         []string{ExampleName},
+			excluded:         nil,
+			expectedExamples: 1,
+		},
+		{
+			name:             "CheckFolderWithExcludedExample",
+			exampleFolder:    CheckFolderWithExampleDir,
+			included:         nil,
+			excluded:         []string{ExampleName},
+			expectedExamples: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			loader.config.ExamplesFrom = tt.exampleFolder
+			loader.config.Examples.Include = tt.included
+			loader.config.Examples.Exclude = tt.excluded
+			err := loader.SearchFolder()
+			if err != nil {
+				t.Errorf("Expected no error, but got: %s", err)
+			}
+
+			assert.Equal(tt.expectedExamples, len(loader.examples))
+			loader.examples = nil
+		})
+	}
+}
+
+func TestExampleLoader_GetFile(t *testing.T) {
+	basePath := ""
+	tempFolderPattern := "ExampleLoaderSearchFolderTests"
+	// Create the ExampleLoader and perform the search
+	loader := ExampleLoader{
+		config:   print.DefaultConfig(),
+		examples: nil, // Initialize with an empty slice
+	}
+
+	ExamplesDir, _ := os.MkdirTemp(basePath, tempFolderPattern)
+	defer os.RemoveAll(ExamplesDir)
+
+	Test1Path := filepath.Join(ExamplesDir, "GetFileTest.tf")
+	Test2Path := filepath.Join(ExamplesDir, "GetBlankFileTest.tf")
+	Test3Path := filepath.Join(ExamplesDir, "FileDoesNotExist.tf")
+
+	os.WriteFile(Test1Path, []byte("File Content"), 0777)
+	os.Create(Test2Path)
+
+	CheckFolderWithoutMaintfDir, _ := os.MkdirTemp(basePath, tempFolderPattern)
+	os.MkdirTemp(CheckFolderWithoutMaintfDir, tempFolderPattern)
+	defer os.RemoveAll(CheckFolderWithoutMaintfDir)
+
+	tests := []struct {
+		name             string
+		exampleFile      string
+		expectedError    bool
+		expectedExamples int
+	}{
+		{
+			name:             "GetFile",
+			exampleFile:      Test1Path,
+			expectedError:    false,
+			expectedExamples: 1,
+		},
+		{
+			name:             "GetBlankFile",
+			exampleFile:      Test2Path,
+			expectedError:    false,
+			expectedExamples: 0,
+		},
+		{
+			name:             "Non-existing file",
+			exampleFile:      Test3Path,
+			expectedError:    true,
+			expectedExamples: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := loader.GetFile(tt.exampleFile)
+
+			if tt.expectedError && err == nil {
+				t.Error("Expected an error, but got nil")
+			}
+
+			if !tt.expectedError && err != nil {
+				t.Errorf("Expected no error, but got: %s", err)
+			}
+
+			assert.Equal(tt.expectedExamples, len(loader.examples))
+			loader.examples = nil
+		})
+	}
+}

--- a/terraform/load.go
+++ b/terraform/load.go
@@ -74,10 +74,12 @@ func loadModuleItems(tfmodule *tfconfig.Module, config *print.Config) (*Module, 
 	providers := loadProviders(tfmodule, config)
 	requirements := loadRequirements(tfmodule)
 	resources := loadResources(tfmodule, config)
+	examples := loadExamples(config)
 
 	return &Module{
 		Header:       header,
 		Footer:       footer,
+		Examples:     examples,
 		Inputs:       inputs,
 		ModuleCalls:  modulecalls,
 		Outputs:      outputs,
@@ -113,6 +115,14 @@ func isFileFormatSupported(filename string, section string) (bool, error) {
 		return true, nil
 	}
 	return false, fmt.Errorf("only .adoc, .md, .tf, and .txt formats are supported to read %s from", section)
+}
+
+func loadExamples(config *print.Config) []*Example {
+	Loader := NewExampleLoader(config)
+
+	Loader.SearchFolder()
+
+	return Loader.examples
 }
 
 func loadHeader(config *print.Config) (string, error) {

--- a/terraform/module.go
+++ b/terraform/module.go
@@ -20,6 +20,7 @@ type Module struct {
 
 	Header       string         `json:"header" toml:"header" xml:"header" yaml:"header"`
 	Footer       string         `json:"footer" toml:"footer" xml:"footer" yaml:"footer"`
+	Examples     []*Example     `json:"examples" toml:"examples" xml:"examples>example" yaml:"examples"`
 	Inputs       []*Input       `json:"inputs" toml:"inputs" xml:"inputs>input" yaml:"inputs"`
 	ModuleCalls  []*ModuleCall  `json:"modules" toml:"modules" xml:"modules>module" yaml:"modules"`
 	Outputs      []*Output      `json:"outputs" toml:"outputs" xml:"outputs>output" yaml:"outputs"`
@@ -39,6 +40,11 @@ func (m *Module) HasHeader() bool {
 // HasFooter indicates if the module has footer.
 func (m *Module) HasFooter() bool {
 	return len(m.Footer) > 0
+}
+
+// Examples indicates if the module has any Examples.
+func (m *Module) HasExamples() bool {
+	return len(m.Examples) > 0
 }
 
 // HasInputs indicates if the module has inputs.


### PR DESCRIPTION
### Description of your changes

#### Description 

Adding an `Examples` section into the tool. The purpose being that if you have a list of examples in a subfolder in your Terraform module repository it will automatically find them and insert them into your documentation. 

For example, I've now added an example to the example module here:
[examples/examples/exampleA/main.tf](examples/examples/exampleA/main.tf)

This takes the modules name (folder name) exampleA and its content (the file contents) and will display it as an additional section if configured to do so. It will take all folder names from 1 level below the `examples` folder, so long as that folder has a `main.tf` file present.

#### Added Config 

Some extra config has been added to support this change. 

`examples-from`: Following the style of footer-from and header-from, the location to take the examples from. This should point to the folder containing module folders. The default value is `./examples` (aligning with Terraform's [Standard Module Structure](https://developer.hashicorp.com/terraform/language/modules/develop/structure))

`section` > `hide`/`show`: Adding `examples` to the hide and show functionality. Example's default state is being hidden to avoid this change being disruptive

`examples` > `include`: A list of strings for what examples to include. These strings match the names of the example, in this case you would put: 

```yml
include:
    - exampleA
```
To include the example in this project. All examples will be shown if neither include or exclude are set.

`examples` > `exclude`: A list of strings for what examples to exclude. This is the same functionality as `include` but in reverse. (attempting to match `show` / `hide`)

`examples` > `limit`: An integer for the maximum number of examples to show. If a project has too many examples then you might want to limit them and at scale you may not be able to include specific examples by name. This takes the first x examples in lexicographic order. If the value is set to 0 then all examples will be shown. The default is 0. 

`examples` > `HideTitles`: By default, in formats like markdown and ascii it will show the title of the example as a header above it. e.g.

```
## Examples

### exampleA

```hcl
module full-example{
    source = "github.com/terraform-docs/terraform-docs//examples"
...
```

but this can be set to `true` to hide the title such that it is just: 
```
## Examples

```hcl
module full-example{
    source = "github.com/terraform-docs/terraform-docs//examples"
...
```

#### Documentation

I'm very happy to update the documentation along with this change but I wanted to gauge interest in the feature / the config setting before continuing with it. (as it may change) Please let me know your thoughts on this and I'll start work on it. 


<!-- Fixes # -->
Fixes #685
Fixes #617 (Not mine, but confident it's the same purpose)
Possibly #599 / #605 (Not my issues and unsure if it 100% meets their needs)
I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

I've added a whole suite of tests /updated tests in for every type of output which support `examples` and am confident that it has functionality in those areas. I've installed this branch locally and have applied it to some of my local projects without issue and have been messing around with the configuration file / combinations of configurations. Happy for feedback on any tests that could be added / edge cases you would like testing, but it seems good for standard use. 

I would be interested for feedback for the more unique formats. I've updated the tests and tried to match the general style of format like pretty / toml / json, but these are typically not my use-cases so I can't say that they are ideally formatted in those areas. 
