### PR TITLE
build: switch to scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN make build
 
 ################
 
-FROM alpine:3.16.1
+FROM scratch
 
 COPY --from=builder /go/src/terraform-docs/bin/linux-amd64/terraform-docs /usr/local/bin/
 


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Switched the base image from `alpine` to `scratch` reducing the image size and potential issues with dependency maintenance.

```
$ podman image ls terraform-docs
localhost/terraform-docs  scratch     c091ac42b71f  5 minutes ago   20.2 MB
localhost/terraform-docs  master      126a7fcbb8a6  10 minutes ago  25.7 MB
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

<!-- Fixes # -->

I have:

- [X] Read and followed terraform-docs' [contribution process].
- [ ] All tests pass when I run `make test`.

### How has this code been tested

I used Podman to run container locally: `podman run --volume $PWD:/terraform-docs terraform-docs:latest markdown /terraform-docs` and it worked seamlessly.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
