### PR TITLE
docs: fix two typos in the 'configuration' section of the documentation

### DIFF
--- a/docs/user-guide/configuration/content.md
+++ b/docs/user-guide/configuration/content.md
@@ -42,7 +42,7 @@ over the `content`.
 
 - `{{ include "relative/path/to/file" }}`
 
-Additionally there's also one extra special variable avaialble to the `content`:
+Additionally there's also one extra special variable available to the `content`:
 
 - `{{ .Module }}`
 

--- a/docs/user-guide/configuration/output.md
+++ b/docs/user-guide/configuration/output.md
@@ -99,7 +99,7 @@ output:
 
 ## Examples
 
-Inject the generated output into `README.md` between the sorrounding comments.
+Inject the generated output into `README.md` between the surrounding comments.
 
 ```yaml
 output:


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fix two typos in the documentation. Could not find any issue related to them.

I have:

- [X] Read and followed terraform-docs' [contribution process].
- [X] All tests pass when I run `make test`.

### How has this code been tested

Ran 'make test'. Looks good. Those are only documentation changes anyway.

[contribution process]: https://git.io/JtEzg
