### PR TITLE
Check if file write failure before reporting success

### DIFF
--- a/internal/cli/writer.go
+++ b/internal/cli/writer.go
@@ -179,6 +179,9 @@ func (fw *fileWriter) write(filename string, p []byte) (int, error) {
 		return fw.writer.Write(p)
 	}
 
-	fmt.Printf("%s updated successfully\n", filename)
-	return len(p), os.WriteFile(filename, p, 0644)
+	err := os.WriteFile(filename, p, 0644)
+	if err == nil {
+		fmt.Printf("%s updated successfully\n", filename)
+	}
+	return len(p), err
 }


### PR DESCRIPTION
### Description of your changes
Checks if there was any file writing error before sending a success message.

Fixes #724

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested
```
vscode ➜ /workspaces/terraform-docs (skipMisleadingSuccessMessage) $ make build && ./bin/linux-amd64/terraform-docs markdown table --output-file test-README.md ./examples/
==> Clean workspace
rm -rf ./bin ./coverage.out
==> Build binary for current OS/ARCH
CGO_ENABLED=0 go build -ldflags="-X github.com/terraform-docs/terraform-docs/internal/version.commit=1d4c250" -o ./bin/linux-amd64/terraform-docs
examples/test-README.md updated successfully
vscode ➜ /workspaces/terraform-docs (skipMisleadingSuccessMessage) $ chmod -w ./examples/test-README.md 
vscode ➜ /workspaces/terraform-docs (skipMisleadingSuccessMessage) $ ./bin/linux-amd64/terraform-docs markdown table --output-file test-README.md ./examples/
Error: open examples/test-README.md: permission denied
vscode ➜ /workspaces/terraform-docs (skipMisleadingSuccessMessage) $ 
```
