### PR TITLE
Update Dockerfile FROM command to use non-ambiguous container sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # You may obtain a copy of the License at the LICENSE file in
 # the root directory of this source tree.
 
-FROM golang:1.22.3-alpine AS builder
+FROM docker.io/library/golang:1.22.3-alpine AS builder
 
 RUN apk add --update --no-cache make
 
@@ -21,7 +21,7 @@ RUN make build
 
 ################
 
-FROM alpine:3.20.0
+FROM docker.io/library/alpine:3.20.0
 
 # Mitigate CVE-2023-5363
 RUN apk add --no-cache --upgrade "openssl>=3.1.4-r1"

--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -6,7 +6,7 @@
 # You may obtain a copy of the License at the LICENSE file in
 # the root directory of this source tree.
 
-FROM alpine:3.20.0
+FROM docker.io/library/alpine:3.20.0
 
 COPY terraform-docs /usr/local/bin/terraform-docs
 


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This will set a non-ambiguous container source for the Dockerfile(s) used in this project. This reduces issues when using non-docker tooling that rely on full container sources. This increases not only verbosity but it also reduces the changes of exploits as explained in the following redhat post [Container image short names](https://www.redhat.com/sysadmin/container-image-short-names)

See also: https://github.com/terraform-docs/terraform-docs/issues/641
Fixes: #641 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

I've tested it locally by running `make test` and was able to build the containers myself using `make docker`.
