### PR TITLE
Fixed binary name in description output of bash completion generation cli command

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -35,17 +35,25 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-const longDescription = `Outputs terraform-doc shell completion for the given shell (bash, zsh, fish)
+const longDescription = `Outputs terraform-docs shell completion for the given shell (bash, zsh, fish)
 This depends on the bash-completion binary.  Example installation instructions:
 # for bash users
-	$ terraform-docs completion bash > ~/.terraform-doc-completion
-	$ source ~/.terraform-doc-completion
+	$ terraform-docs completion bash > ~/.terraform-docs-completion
+	$ source ~/.terraform-docs-completion
+
+	# or the one-liner below
+
+	$ source <(terraform-docs completion bash)
 
 # for zsh users
-	% terraform-docs completion zsh > /usr/local/share/zsh/site-functions/_terraform-doc
+	% terraform-docs completion zsh > /usr/local/share/zsh/site-functions/_terraform-docs
 	% autoload -U compinit && compinit
 # or if zsh-completion is installed via homebrew
-    % terraform-docs completion zsh > "${fpath[1]}/_terraform-doc"
+	% terraform-docs completion zsh > "${fpath[1]}/_terraform-docs"
+
+# for ohmyzsh
+	$ terraform-docs completion zsh > ~/.oh-my-zsh/completions/_terraform-docs
+	$ omz reload
 
 # for fish users
 	$ terraform-docs completion fish > ~/.config/fish/completions/terraform-docs.fish

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -38,17 +38,17 @@ func NewCommand() *cobra.Command {
 const longDescription = `Outputs terraform-doc shell completion for the given shell (bash, zsh, fish)
 This depends on the bash-completion binary.  Example installation instructions:
 # for bash users
-	$ terraform-doc completion bash > ~/.terraform-doc-completion
+	$ terraform-docs completion bash > ~/.terraform-doc-completion
 	$ source ~/.terraform-doc-completion
 
 # for zsh users
-	% terraform-doc completion zsh > /usr/local/share/zsh/site-functions/_terraform-doc
+	% terraform-docs completion zsh > /usr/local/share/zsh/site-functions/_terraform-doc
 	% autoload -U compinit && compinit
 # or if zsh-completion is installed via homebrew
-    % terraform-doc completion zsh > "${fpath[1]}/_terraform-doc"
+    % terraform-docs completion zsh > "${fpath[1]}/_terraform-doc"
 
 # for fish users
-	$ terraform-doc completion fish > ~/.config/fish/completions/terraform-docs.fish
+	$ terraform-docs completion fish > ~/.config/fish/completions/terraform-docs.fish
 
 Additionally, you may want to output the completion to a file and source in your .bashrc
 Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -153,7 +153,7 @@ omz reload
 ### fish
 
 ```fish
-terraform-doc completion fish > ~/.config/fish/completions/terraform-docs.fish
+terraform-docs completion fish > ~/.config/fish/completions/terraform-docs.fish
 ```
 
 To make this change permanent, the above commands can be added to `~/.profile` file.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -214,7 +214,7 @@ func (r *Runtime) bindFlags(v *viper.Viper) {
 		switch f.Name {
 		case "show", "hide":
 			// If '--show' or '--hide' CLI flag is used, explicitly override and remove
-			// all items from 'show' and 'hide' set in '.terraform-doc.yml'.
+			// all items from 'show' and 'hide' set in '.terraform-docs.yml'.
 			if !sectionsCleared {
 				v.Set("sections.show", []string{})
 				v.Set("sections.hide", []string{})


### PR DESCRIPTION
### Description of your changes

Added missing "s" character in binary name of the "bash completion CLI helptext" output.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [ ] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Run `make test`. Since i'm not go developer i'm not sure why the tests of a "plain" repo clone on the master branch fails, but my branch also fails after the doc changes... ?!
```
PASS
coverage: 89.5% of statements
ok  	github.com/terraform-docs/terraform-docs/internal/types	0.006s	coverage: 89.5% of statements
FAIL	github.com/terraform-docs/terraform-docs/print [build failed]
FAIL	github.com/terraform-docs/terraform-docs/template [build failed]
FAIL	github.com/terraform-docs/terraform-docs/terraform [build failed]
make: *** [Makefile:77: test] Error 2
```
