### PR TITLE
docs: document `terraform-docs` + `ohmyzsh` usage

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -143,10 +143,17 @@ terraform-docs completion zsh > /usr/local/share/zsh/site-functions/_terraform-d
 autoload -U compinit && compinit
 ```
 
+### ohmyzsh
+
+```zsh
+terraform-docs completion zsh > ~/.oh-my-zsh/completions/_terraform-docs
+omz reload
+```
+
 ### fish
 
 ```fish
-terraform-doc completion fish > ~/.config/fish/completions/terraform-docs.fish   
+terraform-doc completion fish > ~/.config/fish/completions/terraform-docs.fish
 ```
 
 To make this change permanent, the above commands can be added to `~/.profile` file.


### PR DESCRIPTION
### Description of your changes

Adds instructions for configuring `terraform-docs` completions with [`ohmyzsh`](https://ohmyz.sh/) shell.

### How has this code been tested

I use `terragrunt`, `terraform`, `terraform-docs`, and `ohmyzsh` (with `terraform` plugin)

Versions:
* os: `Debian GNU/Linux 12 (bookworm)`
* `terraform-docs`: `terraform-docs version v0.17.0 795d369 linux/amd64`
* `omz`: `master (667fdbf)`

Steps:
* download latest binary for `linux/amd64`
* install `terraform-docs` into `/usr/bin/local`
* `omz reload` (makes `terraform-docs` available on `$PATH`)
* `terraform-docs completion zsh > ~/.oh-my-zsh/completions/_terraform-docs`
* `omz reload`

Results: 

* Tab completing `terra` within `terraform-docs` repository for this pr's fork.
![Screenshot from 2023-12-29 10-38-11](https://github.com/terraform-docs/terraform-docs/assets/29284192/ef61e2df-0cdc-4a1c-a6e5-e700f8a6a77d)

* Tab completing `terraform-docs` shows options.
![Screenshot from 2023-12-29 10-40-39](https://github.com/terraform-docs/terraform-docs/assets/29284192/842a2510-8d76-40ad-80a7-292047c1b862)

* Tab/Shift+Tab for selecting options.
![Screenshot from 2023-12-29 10-41-44](https://github.com/terraform-docs/terraform-docs/assets/29284192/3abdf30d-3029-49e8-a03e-2cdb0a333e58)

---

closes #742
