### PR TITLE
Add support for closed ATX headers in Markdown output

### DIFF
--- a/cmd/markdown/markdown.go
+++ b/cmd/markdown/markdown.go
@@ -33,6 +33,7 @@ func NewCommand(runtime *cli.Runtime, config *print.Config) *cobra.Command {
 
 	// flags
 	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
+	cmd.PersistentFlags().BoolVar(&config.Settings.AtxClosed, "atx-closed", false, "close ATX style headers")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Escape, "escape", true, "escape special characters")
 	cmd.PersistentFlags().BoolVar(&config.Settings.HTML, "html", true, "use HTML tags in genereted output")

--- a/format/markdown_document_test.go
+++ b/format/markdown_document_test.go
@@ -138,6 +138,23 @@ func TestMarkdownDocument(t *testing.T) {
 				}),
 			),
 		},
+		"WithAtxClosed": {
+			config: testutil.WithSections(
+				testutil.WithHTML(),
+				testutil.With(func(c *print.Config) {
+					c.Settings.AtxClosed = true
+				}),
+			),
+		},
+		"EmptyWithAtxClosed": {
+			config: testutil.WithDefaultSections(
+				testutil.WithHTML(),
+				testutil.With(func(c *print.Config) {
+					c.ModuleRoot = "empty"
+					c.Settings.AtxClosed = true
+				}),
+			),
+		},
 
 		// Only section
 		"OnlyDataSources": {

--- a/format/markdown_table_test.go
+++ b/format/markdown_table_test.go
@@ -138,6 +138,23 @@ func TestMarkdownTable(t *testing.T) {
 				}),
 			),
 		},
+		"WithAtxClosed": {
+			config: testutil.WithSections(
+				testutil.WithHTML(),
+				testutil.With(func(c *print.Config) {
+					c.Settings.AtxClosed = true
+				}),
+			),
+		},
+		"EmptyWithAtxClosed": {
+			config: testutil.WithDefaultSections(
+				testutil.WithHTML(),
+				testutil.With(func(c *print.Config) {
+					c.ModuleRoot = "empty"
+					c.Settings.AtxClosed = true
+				}),
+			),
+		},
 
 		// Only section
 		"OnlyDataSources": {

--- a/format/templates/markdown_document_inputs.tmpl
+++ b/format/templates/markdown_document_inputs.tmpl
@@ -2,17 +2,17 @@
     {{- if .Config.Settings.Required -}}
         {{- if not .Module.RequiredInputs -}}
             {{- if not .Config.Settings.HideEmpty -}}
-                {{- indent 0 "#" }} Required Inputs
+                {{- indent 0 "#" }} Required Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
                 No required inputs.
             {{ end }}
         {{ else }}
-            {{- indent 0 "#" }} Required Inputs
+            {{- indent 0 "#" }} Required Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             The following input variables are required:
             {{- range .Module.RequiredInputs }}
                 {{ printf "\n" }}
-                {{ indent 1 "#" }} {{ anchorNameMarkdown "input" .Name }}
+                {{ indent 1 "#" }} {{ anchorNameMarkdown "input" .Name }}{{ if $.Config.Settings.AtxClosed }} {{ indent 1 "#" }}{{ end }}
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
@@ -29,17 +29,17 @@
         {{- end }}
         {{- if not .Module.OptionalInputs -}}
             {{- if not .Config.Settings.HideEmpty -}}
-                {{- indent 0 "#" }} Optional Inputs
+                {{- indent 0 "#" }} Optional Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
                 No optional inputs.
             {{ end }}
         {{ else }}
-            {{- indent 0 "#" }} Optional Inputs
+            {{- indent 0 "#" }} Optional Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             The following input variables are optional (have default values):
             {{- range .Module.OptionalInputs }}
                 {{ printf "\n" }}
-                {{ indent 1 "#" }} {{ anchorNameMarkdown "input" .Name }}
+                {{ indent 1 "#" }} {{ anchorNameMarkdown "input" .Name }}{{ if $.Config.Settings.AtxClosed }} {{ indent 1 "#" }}{{ end }}
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 
@@ -57,17 +57,17 @@
     {{ else -}}
         {{- if not .Module.Inputs -}}
             {{- if not .Config.Settings.HideEmpty -}}
-                {{- indent 0 "#" }} Inputs
+                {{- indent 0 "#" }} Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
                 No inputs.
             {{ end }}
         {{ else }}
-            {{- indent 0 "#" }} Inputs
+            {{- indent 0 "#" }} Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             The following input variables are supported:
             {{- range .Module.Inputs }}
                 {{ printf "\n" }}
-                {{ indent 1 "#" }} {{ anchorNameMarkdown "input" .Name }}
+                {{ indent 1 "#" }} {{ anchorNameMarkdown "input" .Name }}{{ if $.Config.Settings.AtxClosed }} {{ indent 1 "#" }}{{ end }}
 
                 Description: {{ tostring .Description | sanitizeDoc }}
 

--- a/format/templates/markdown_document_modules.tmpl
+++ b/format/templates/markdown_document_modules.tmpl
@@ -1,17 +1,17 @@
 {{- if .Config.Sections.ModuleCalls -}}
     {{- if not .Module.ModuleCalls -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Modules
+            {{- indent 0 "#" }} Modules{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No modules.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Modules
+        {{- indent 0 "#" }} Modules{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         The following Modules are called:
         {{- range .Module.ModuleCalls }}
 
-            {{ indent 1 "#" }} {{ anchorNameMarkdown "module" .Name }}
+            {{ indent 1 "#" }} {{ anchorNameMarkdown "module" .Name }}{{ if $.Config.Settings.AtxClosed }} {{ indent 1 "#" }}{{ end }}
 
             Source: {{ .Source }}
 

--- a/format/templates/markdown_document_outputs.tmpl
+++ b/format/templates/markdown_document_outputs.tmpl
@@ -1,17 +1,17 @@
 {{- if .Config.Sections.Outputs -}}
     {{- if not .Module.Outputs -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Outputs
+            {{- indent 0 "#" }} Outputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No outputs.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Outputs
+        {{- indent 0 "#" }} Outputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         The following outputs are exported:
         {{- range .Module.Outputs }}
 
-            {{ indent 1 "#" }} {{ anchorNameMarkdown "output" .Name }}
+            {{ indent 1 "#" }} {{ anchorNameMarkdown "output" .Name }}{{ if $.Config.Settings.AtxClosed }} {{ indent 1 "#" }}{{ end }}
 
             Description: {{ tostring .Description | sanitizeDoc }}
 

--- a/format/templates/markdown_document_providers.tmpl
+++ b/format/templates/markdown_document_providers.tmpl
@@ -1,12 +1,12 @@
 {{- if .Config.Sections.Providers -}}
     {{- if not .Module.Providers -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Providers
+            {{- indent 0 "#" }} Providers{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No providers.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Providers
+        {{- indent 0 "#" }} Providers{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         The following providers are used by this module:
         {{- range .Module.Providers }}

--- a/format/templates/markdown_document_requirements.tmpl
+++ b/format/templates/markdown_document_requirements.tmpl
@@ -1,12 +1,12 @@
 {{- if .Config.Sections.Requirements -}}
     {{- if not .Module.Requirements -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Requirements
+            {{- indent 0 "#" }} Requirements{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No requirements.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Requirements
+        {{- indent 0 "#" }} Requirements{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         The following requirements are needed by this module:
         {{- range .Module.Requirements }}

--- a/format/templates/markdown_document_resources.tmpl
+++ b/format/templates/markdown_document_resources.tmpl
@@ -1,12 +1,12 @@
 {{- if or .Config.Sections.Resources .Config.Sections.DataSources -}}
     {{- if not .Module.Resources -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Resources
+            {{- indent 0 "#" }} Resources{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No resources.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Resources
+        {{- indent 0 "#" }} Resources{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         The following resources are used by this module:
         {{ range .Module.Resources }}

--- a/format/templates/markdown_table_inputs.tmpl
+++ b/format/templates/markdown_table_inputs.tmpl
@@ -1,12 +1,12 @@
 {{- if .Config.Sections.Inputs -}}
     {{- if not .Module.Inputs -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Inputs
+            {{- indent 0 "#" }} Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No inputs.
         {{- end }}
     {{ else }}
-        {{- indent 0 "#" }} Inputs
+        {{- indent 0 "#" }} Inputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         | Name | Description |
         {{- if .Config.Settings.Type }} Type |{{ end }}

--- a/format/templates/markdown_table_modules.tmpl
+++ b/format/templates/markdown_table_modules.tmpl
@@ -1,12 +1,12 @@
 {{- if .Config.Sections.ModuleCalls -}}
     {{- if not .Module.ModuleCalls -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Modules
+            {{- indent 0 "#" }} Modules{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No modules.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Modules
+        {{- indent 0 "#" }} Modules{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         | Name | Source | Version |
         |------|--------|---------|

--- a/format/templates/markdown_table_outputs.tmpl
+++ b/format/templates/markdown_table_outputs.tmpl
@@ -1,12 +1,12 @@
 {{- if .Config.Sections.Outputs -}}
     {{- if not .Module.Outputs -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Outputs
+            {{- indent 0 "#" }} Outputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No outputs.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Outputs
+        {{- indent 0 "#" }} Outputs{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         | Name | Description |{{ if .Config.OutputValues.Enabled }} Value |{{ if $.Config.Settings.Sensitive }} Sensitive |{{ end }}{{ end }}
         |------|-------------|{{ if .Config.OutputValues.Enabled }}-------|{{ if $.Config.Settings.Sensitive }}:---------:|{{ end }}{{ end }}

--- a/format/templates/markdown_table_providers.tmpl
+++ b/format/templates/markdown_table_providers.tmpl
@@ -1,12 +1,12 @@
 {{- if .Config.Sections.Providers -}}
     {{- if not .Module.Providers -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Providers
+            {{- indent 0 "#" }} Providers{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No providers.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Providers
+        {{- indent 0 "#" }} Providers{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         | Name | Version |
         |------|---------|

--- a/format/templates/markdown_table_requirements.tmpl
+++ b/format/templates/markdown_table_requirements.tmpl
@@ -1,12 +1,12 @@
 {{- if .Config.Sections.Requirements -}}
     {{- if not .Module.Requirements -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Requirements
+            {{- indent 0 "#" }} Requirements{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No requirements.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Requirements
+        {{- indent 0 "#" }} Requirements{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         | Name | Version |
         |------|---------|

--- a/format/templates/markdown_table_resources.tmpl
+++ b/format/templates/markdown_table_resources.tmpl
@@ -1,12 +1,12 @@
 {{- if or .Config.Sections.Resources .Config.Sections.DataSources -}}
     {{- if not .Module.Resources -}}
         {{- if not .Config.Settings.HideEmpty -}}
-            {{- indent 0 "#" }} Resources
+            {{- indent 0 "#" }} Resources{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
             No resources.
         {{ end }}
     {{ else }}
-        {{- indent 0 "#" }} Resources
+        {{- indent 0 "#" }} Resources{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         | Name | Type |
         |------|------|

--- a/format/testdata/markdown/document-EmptyWithAtxClosed.golden
+++ b/format/testdata/markdown/document-EmptyWithAtxClosed.golden
@@ -1,0 +1,23 @@
+## Requirements ##
+
+No requirements.
+
+## Providers ##
+
+No providers.
+
+## Modules ##
+
+No modules.
+
+## Resources ##
+
+No resources.
+
+## Inputs ##
+
+No inputs.
+
+## Outputs ##
+
+No outputs.

--- a/format/testdata/markdown/document-WithAtxClosed.golden
+++ b/format/testdata/markdown/document-WithAtxClosed.golden
@@ -1,0 +1,436 @@
+Usage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
+## Requirements ##
+
+The following requirements are needed by this module:
+
+- terraform (>= 0.12)
+
+- aws (>= 2.15.0)
+
+- foo (>= 1.0)
+
+- random (>= 2.2.0)
+
+## Providers ##
+
+The following providers are used by this module:
+
+- tls
+
+- foo (>= 1.0)
+
+- aws (>= 2.15.0)
+
+- aws.ident (>= 2.15.0)
+
+- null
+
+## Modules ##
+
+The following Modules are called:
+
+### bar ###
+
+Source: baz
+
+Version: 4.5.6
+
+### foo ###
+
+Source: bar
+
+Version: 1.2.3
+
+### baz ###
+
+Source: baz
+
+Version: 4.5.6
+
+### foobar ###
+
+Source: git@github.com:module/path
+
+Version: v7.8.9
+
+## Resources ##
+
+The following resources are used by this module:
+
+- foo_resource.baz (resource)
+- [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
+- [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
+- [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+- [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
+
+## Inputs ##
+
+The following input variables are supported:
+
+### unquoted ###
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### bool-3 ###
+
+Description: n/a
+
+Type: `bool`
+
+Default: `true`
+
+### bool-2 ###
+
+Description: It's bool number two.
+
+Type: `bool`
+
+Default: `false`
+
+### bool-1 ###
+
+Description: It's bool number one.
+
+Type: `bool`
+
+Default: `true`
+
+### string-3 ###
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2 ###
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1 ###
+
+Description: It's string number one.
+
+Type: `string`
+
+Default: `"bar"`
+
+### string-special-chars ###
+
+Description: n/a
+
+Type: `string`
+
+Default: `"\\.<>[]{}_-"`
+
+### number-3 ###
+
+Description: n/a
+
+Type: `number`
+
+Default: `"19"`
+
+### number-4 ###
+
+Description: n/a
+
+Type: `number`
+
+Default: `15.75`
+
+### number-2 ###
+
+Description: It's number number two.
+
+Type: `number`
+
+Default: n/a
+
+### number-1 ###
+
+Description: It's number number one.
+
+Type: `number`
+
+Default: `42`
+
+### map-3 ###
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2 ###
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1 ###
+
+Description: It's map number one.
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3 ###
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2 ###
+
+Description: It's list number two.
+
+Type: `list`
+
+Default: n/a
+
+### list-1 ###
+
+Description: It's list number one.
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "a",
+  "b",
+  "c"
+]
+```
+
+### input_with_underscores ###
+
+Description: A variable with underscores.
+
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe ###
+
+Description: It includes v1 | v2 | v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block ###
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
+
+### long_type ###
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Type:
+
+```hcl
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+```
+
+Default:
+
+```json
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+```
+
+### no-escape-default-value ###
+
+Description: The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+
+Type: `string`
+
+Default: `"VALUE_WITH_UNDERSCORE"`
+
+### with-url ###
+
+Description: The description contains url. https://www.domain.com/foo/bar_baz.html
+
+Type: `string`
+
+Default: `""`
+
+### string_default_empty ###
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string_default_null ###
+
+Description: n/a
+
+Type: `string`
+
+Default: `null`
+
+### string_no_default ###
+
+Description: n/a
+
+Type: `string`
+
+Default: n/a
+
+### number_default_zero ###
+
+Description: n/a
+
+Type: `number`
+
+Default: `0`
+
+### bool_default_false ###
+
+Description: n/a
+
+Type: `bool`
+
+Default: `false`
+
+### list_default_empty ###
+
+Description: n/a
+
+Type: `list(string)`
+
+Default: `[]`
+
+### object_default_empty ###
+
+Description: n/a
+
+Type: `object({})`
+
+Default: `{}`
+
+## Outputs ##
+
+The following outputs are exported:
+
+### unquoted ###
+
+Description: It's unquoted output.
+
+### output-2 ###
+
+Description: It's output number two.
+
+### output-1 ###
+
+Description: It's output number one.
+
+### output-0.12 ###
+
+Description: terraform 0.12 only
+
+## This is an example of a footer
+
+It looks exactly like a header, but is placed at the end of the document

--- a/format/testdata/markdown/table-EmptyWithAtxClosed.golden
+++ b/format/testdata/markdown/table-EmptyWithAtxClosed.golden
@@ -1,0 +1,23 @@
+## Requirements ##
+
+No requirements.
+
+## Providers ##
+
+No providers.
+
+## Modules ##
+
+No modules.
+
+## Resources ##
+
+No resources.
+
+## Inputs ##
+
+No inputs.
+
+## Outputs ##
+
+No outputs.

--- a/format/testdata/markdown/table-WithAtxClosed.golden
+++ b/format/testdata/markdown/table-WithAtxClosed.golden
@@ -1,0 +1,124 @@
+Usage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.15.0 |
+| foo | >= 1.0 |
+| random | >= 2.2.0 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| tls | n/a |
+| foo | >= 1.0 |
+| aws | >= 2.15.0 |
+| aws.ident | >= 2.15.0 |
+| null | n/a |
+
+## Modules ##
+
+| Name | Source | Version |
+|------|--------|---------|
+| bar | baz | 4.5.6 |
+| foo | bar | 1.2.3 |
+| baz | baz | 4.5.6 |
+| foobar | git@github.com:module/path | v7.8.9 |
+
+## Resources ##
+
+| Name | Type |
+|------|------|
+| foo_resource.baz | resource |
+| [null_resource.foo](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [tls_private_key.baz](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.ident](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs ##
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| unquoted | n/a | `any` | n/a |
+| bool-3 | n/a | `bool` | `true` |
+| bool-2 | It's bool number two. | `bool` | `false` |
+| bool-1 | It's bool number one. | `bool` | `true` |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | It's string number one. | `string` | `"bar"` |
+| string-special-chars | n/a | `string` | `"\\.<>[]{}_-"` |
+| number-3 | n/a | `number` | `"19"` |
+| number-4 | n/a | `number` | `15.75` |
+| number-2 | It's number number two. | `number` | n/a |
+| number-1 | It's number number one. | `number` | `42` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
+| no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
+| with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
+| string_default_empty | n/a | `string` | `""` |
+| string_default_null | n/a | `string` | `null` |
+| string_no_default | n/a | `string` | n/a |
+| number_default_zero | n/a | `number` | `0` |
+| bool_default_false | n/a | `bool` | `false` |
+| list_default_empty | n/a | `list(string)` | `[]` |
+| object_default_empty | n/a | `object({})` | `{}` |
+
+## Outputs ##
+
+| Name | Description |
+|------|-------------|
+| unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | It's output number one. |
+| output-0.12 | terraform 0.12 only |
+
+## This is an example of a footer
+
+It looks exactly like a header, but is placed at the end of the document

--- a/print/config.go
+++ b/print/config.go
@@ -380,6 +380,7 @@ func (s *sort) validate() error {
 
 type settings struct {
 	Anchor       bool `mapstructure:"anchor"`
+	AtxClosed    bool `mapstructure:"atx-closed"`
 	Color        bool `mapstructure:"color"`
 	Default      bool `mapstructure:"default"`
 	Description  bool `mapstructure:"description"`
@@ -397,6 +398,7 @@ type settings struct {
 func defaultSettings() settings {
 	return settings{
 		Anchor:       true,
+		AtxClosed:    false,
 		Color:        true,
 		Default:      true,
 		Description:  false,


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This adds a new `atx-closed` option to support Markdown output with closed ATX headers. The default value is `false` to be consistent with the current output of open ATX headers.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #744 

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

I added tests that are identical to the Markdown Base and Empty Markdown tests but changed the new option to `true`. Appropriate golden outputs were added to ensure correct output.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
