### PR TITLE
Add functionality that allows header-from and footer-from to get references from external sources

### DIFF
--- a/docs/user-guide/configuration/footer-from.md
+++ b/docs/user-guide/configuration/footer-from.md
@@ -10,7 +10,7 @@ toc: true
 
 Since `v0.12.0`
 
-Relative path to a file to extract footer for the generated output from. Supported
+Relative path to a file or external source (http, https, s3) to extract footer for the generated output from. Supported
 file formats are `.adoc`, `.md`, `.tf`, and `.txt`.
 
 {{< alert type="info" >}}
@@ -67,4 +67,10 @@ Read `docs/.footer.md` to extract footer:
 
 ```yaml
 footer-from: "docs/.footer.md"
+```
+
+Read `https://raw.githubusercontent.com/terraform-docs/terraform-docs/master/terraform/testdata/full-example/doc.md` to extract footer:
+
+```yaml
+header-from: "https://raw.githubusercontent.com/terraform-docs/terraform-docs/master/terraform/testdata/full-example/doc.md"
 ```

--- a/docs/user-guide/configuration/header-from.md
+++ b/docs/user-guide/configuration/header-from.md
@@ -10,7 +10,7 @@ toc: true
 
 Since `v0.10.0`
 
-Relative path to a file to extract header for the generated output from. Supported
+Relative path to a file or external source (http, https, s3) to extract header for the generated output from. Supported
 file formats are `.adoc`, `.md`, `.tf`, and `.txt`.
 
 {{< alert type="info" >}}
@@ -67,4 +67,10 @@ Read `docs/.header.md` to extract header:
 
 ```yaml
 header-from: "docs/.header.md"
+```
+
+Read `https://raw.githubusercontent.com/terraform-docs/terraform-docs/master/terraform/testdata/full-example/doc.md` to extract header:
+
+```yaml
+header-from: "https://raw.githubusercontent.com/terraform-docs/terraform-docs/master/terraform/testdata/full-example/doc.md"
 ```


### PR DESCRIPTION


<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Add functionality that allows header-from and footer-from to get references from external sources

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Feature Request
#600 
#590 

To address this new feature, we read the prefix of the file name (header-from, footer-from) and if it contains https, https, or s3; we make an HTTP request and save the information in a temporal file until the content is saved in the variables of the program.


I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested
We tested it with an .md file in GitHub repository as raw data, we also added test cases for this.


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
