### PR TITLE
Display `configuration_aliases` associated with `required_providers`

### DIFF
--- a/docs/reference/pretty.md
+++ b/docs/reference/pretty.md
@@ -96,7 +96,7 @@ generates the following output:
 
 
     requirement.terraform (>= 0.12)
-    requirement.aws (>= 2.15.0)
+    requirement.aws (>= 2.15.0) (aliases: aws,aws.ident)
     requirement.foo (>= 1.0)
     requirement.random (>= 2.2.0)
 
@@ -136,7 +136,7 @@ generates the following output:
     input.input-with-code-block ([
       "name rack:location"
     ])
-    This is a complicated one. We need a newline.  
+    This is a complicated one. We need a newline.
     And an example in a code block
     ```
     default     = [

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -42,7 +42,13 @@ terraform {
   required_version = ">= 0.12"
   required_providers {
     random = ">= 2.2.0"
-    aws    = ">= 2.15.0"
+    aws    = {
+      version = ">= 2.15.0"
+      configuration_aliases = [
+        aws,
+        aws.ident
+      ]
+    }
     foo = {
       source  = "https://registry.acme.com/foo"
       version = ">= 1.0"

--- a/format/templates/asciidoc_document_requirements.tmpl
+++ b/format/templates/asciidoc_document_requirements.tmpl
@@ -11,7 +11,8 @@
         The following requirements are needed by this module:
         {{- range .Module.Requirements }}
             {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
-            - {{ anchorNameAsciidoc "requirement" .Name }}{{ $version }}
+            {{ $aliases := ternary (tostring .ConfigurationAliases) (printf " (aliases: %s)" .ConfigurationAliases) "" }}
+            - {{ anchorNameAsciidoc "requirement" .Name }}{{ $version }}{{ $aliases }}
         {{- end }}
     {{ end }}
 {{ end -}}

--- a/format/templates/asciidoc_table_requirements.tmpl
+++ b/format/templates/asciidoc_table_requirements.tmpl
@@ -10,9 +10,9 @@
 
         [cols="a,a",options="header,autowidth"]
         |===
-        |Name |Version
+        |Name |Version |Aliases
         {{- range .Module.Requirements }}
-            |{{ anchorNameAsciidoc "requirement" .Name }} |{{ tostring .Version | default "n/a" }}
+            |{{ anchorNameAsciidoc "requirement" .Name }} |{{ tostring .Version | default "n/a" }} |{{ tostring .ConfigurationAliases | default "n/a" }} 
         {{- end }}
         |===
     {{ end }}

--- a/format/templates/markdown_document_requirements.tmpl
+++ b/format/templates/markdown_document_requirements.tmpl
@@ -11,7 +11,8 @@
         The following requirements are needed by this module:
         {{- range .Module.Requirements }}
             {{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
-            - {{ anchorNameMarkdown "requirement" .Name }}{{ $version }}
+            {{ $aliases := ternary (tostring .ConfigurationAliases) (printf " (aliases: %s)" .ConfigurationAliases) "" }}
+            - {{ anchorNameMarkdown "requirement" .Name }}{{ $version }}{{ $aliases }}
         {{- end }}
     {{ end }}
 {{ end -}}

--- a/format/templates/markdown_table_requirements.tmpl
+++ b/format/templates/markdown_table_requirements.tmpl
@@ -8,10 +8,10 @@
     {{ else }}
         {{- indent 0 "#" }} Requirements
 
-        | Name | Version |
-        |------|---------|
+        | Name | Version | Aliases |
+        |------|---------|---------|
         {{- range .Module.Requirements }}
-            | {{ anchorNameMarkdown "requirement" .Name }} | {{ tostring .Version | default "n/a" }} |
+            | {{ anchorNameMarkdown "requirement" .Name }} | {{ tostring .Version | default "n/a" }} | {{ tostring .ConfigurationAliases | default "n/a" }} | 
         {{- end }}
     {{ end }}
 {{ end -}}

--- a/format/templates/pretty.tmpl
+++ b/format/templates/pretty.tmpl
@@ -9,7 +9,8 @@
     {{- with .Module.Requirements }}
         {{- range . }}
             {{- $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
-            {{- printf "requirement.%s" .Name | colorize "\033[36m" }}{{ $version }}
+            {{- $aliases := ternary (tostring .ConfigurationAliases) (printf " (aliases: %s)" .ConfigurationAliases) "" }}
+            {{- printf "requirement.%s" .Name | colorize "\033[36m" }}{{ $version }}{{ $aliases }}
         {{ end -}}
     {{ end -}}
     {{- printf "\n\n" -}}

--- a/format/testdata/asciidoc/document-Base.golden
+++ b/format/testdata/asciidoc/document-Base.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/asciidoc/document-IndentationOfFour.golden
+++ b/format/testdata/asciidoc/document-IndentationOfFour.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/asciidoc/document-OnlyRequirements.golden
+++ b/format/testdata/asciidoc/document-OnlyRequirements.golden
@@ -4,7 +4,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/asciidoc/document-WithAnchor.golden
+++ b/format/testdata/asciidoc/document-WithAnchor.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - [[requirement_terraform]] <<requirement_terraform,terraform>> (>= 0.12)
 
-- [[requirement_aws]] <<requirement_aws,aws>> (>= 2.15.0)
+- [[requirement_aws]] <<requirement_aws,aws>> (>= 2.15.0) (aliases: aws,aws.ident)
 
 - [[requirement_foo]] <<requirement_foo,foo>> (>= 1.0)
 

--- a/format/testdata/asciidoc/document-WithRequired.golden
+++ b/format/testdata/asciidoc/document-WithRequired.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/asciidoc/table-Base.golden
+++ b/format/testdata/asciidoc/table-Base.golden
@@ -40,11 +40,11 @@ followed by another line of text.
 
 [cols="a,a",options="header,autowidth"]
 |===
-|Name |Version
-|terraform |>= 0.12
-|aws |>= 2.15.0
-|foo |>= 1.0
-|random |>= 2.2.0
+|Name |Version |Aliases
+|terraform |>= 0.12 |n/a
+|aws |>= 2.15.0 |aws,aws.ident
+|foo |>= 1.0 |n/a
+|random |>= 2.2.0 |n/a
 |===
 
 == Providers

--- a/format/testdata/asciidoc/table-IndentationOfFour.golden
+++ b/format/testdata/asciidoc/table-IndentationOfFour.golden
@@ -40,11 +40,11 @@ followed by another line of text.
 
 [cols="a,a",options="header,autowidth"]
 |===
-|Name |Version
-|terraform |>= 0.12
-|aws |>= 2.15.0
-|foo |>= 1.0
-|random |>= 2.2.0
+|Name |Version |Aliases
+|terraform |>= 0.12 |n/a
+|aws |>= 2.15.0 |aws,aws.ident
+|foo |>= 1.0 |n/a
+|random |>= 2.2.0 |n/a
 |===
 
 ==== Providers

--- a/format/testdata/asciidoc/table-OnlyRequirements.golden
+++ b/format/testdata/asciidoc/table-OnlyRequirements.golden
@@ -2,9 +2,9 @@
 
 [cols="a,a",options="header,autowidth"]
 |===
-|Name |Version
-|terraform |>= 0.12
-|aws |>= 2.15.0
-|foo |>= 1.0
-|random |>= 2.2.0
+|Name |Version |Aliases
+|terraform |>= 0.12 |n/a
+|aws |>= 2.15.0 |aws,aws.ident
+|foo |>= 1.0 |n/a
+|random |>= 2.2.0 |n/a
 |===

--- a/format/testdata/asciidoc/table-WithAnchor.golden
+++ b/format/testdata/asciidoc/table-WithAnchor.golden
@@ -40,11 +40,11 @@ followed by another line of text.
 
 [cols="a,a",options="header,autowidth"]
 |===
-|Name |Version
-|[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.12
-|[[requirement_aws]] <<requirement_aws,aws>> |>= 2.15.0
-|[[requirement_foo]] <<requirement_foo,foo>> |>= 1.0
-|[[requirement_random]] <<requirement_random,random>> |>= 2.2.0
+|Name |Version |Aliases
+|[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.12 |n/a
+|[[requirement_aws]] <<requirement_aws,aws>> |>= 2.15.0 |aws,aws.ident
+|[[requirement_foo]] <<requirement_foo,foo>> |>= 1.0 |n/a
+|[[requirement_random]] <<requirement_random,random>> |>= 2.2.0 |n/a
 |===
 
 == Providers

--- a/format/testdata/asciidoc/table-WithRequired.golden
+++ b/format/testdata/asciidoc/table-WithRequired.golden
@@ -40,11 +40,11 @@ followed by another line of text.
 
 [cols="a,a",options="header,autowidth"]
 |===
-|Name |Version
-|terraform |>= 0.12
-|aws |>= 2.15.0
-|foo |>= 1.0
-|random |>= 2.2.0
+|Name |Version |Aliases
+|terraform |>= 0.12 |n/a
+|aws |>= 2.15.0 |aws,aws.ident
+|foo |>= 1.0 |n/a
+|random |>= 2.2.0 |n/a
 |===
 
 == Providers

--- a/format/testdata/json/json-Base.golden
+++ b/format/testdata/json/json-Base.golden
@@ -323,7 +323,8 @@
     },
     {
       "name": "aws",
-      "version": ">= 2.15.0"
+      "version": ">= 2.15.0",
+      "aliases": "aws,aws.ident"
     },
     {
       "name": "foo",

--- a/format/testdata/json/json-EscapeCharacters.golden
+++ b/format/testdata/json/json-EscapeCharacters.golden
@@ -323,7 +323,8 @@
     },
     {
       "name": "aws",
-      "version": "\u003e= 2.15.0"
+      "version": "\u003e= 2.15.0",
+      "aliases": "aws,aws.ident"
     },
     {
       "name": "foo",

--- a/format/testdata/json/json-OnlyRequirements.golden
+++ b/format/testdata/json/json-OnlyRequirements.golden
@@ -12,7 +12,8 @@
     },
     {
       "name": "aws",
-      "version": ">= 2.15.0"
+      "version": ">= 2.15.0",
+      "aliases": "aws,aws.ident"
     },
     {
       "name": "foo",

--- a/format/testdata/markdown/document-Base.golden
+++ b/format/testdata/markdown/document-Base.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/markdown/document-EscapeCharacters.golden
+++ b/format/testdata/markdown/document-EscapeCharacters.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/markdown/document-IndentationOfFour.golden
+++ b/format/testdata/markdown/document-IndentationOfFour.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/markdown/document-OnlyRequirements.golden
+++ b/format/testdata/markdown/document-OnlyRequirements.golden
@@ -4,7 +4,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/markdown/document-WithAnchor.golden
+++ b/format/testdata/markdown/document-WithAnchor.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement_terraform) (>= 0.12)
 
-- <a name="requirement_aws"></a> [aws](#requirement_aws) (>= 2.15.0)
+- <a name="requirement_aws"></a> [aws](#requirement_aws) (>= 2.15.0) (aliases: aws,aws.ident)
 
 - <a name="requirement_foo"></a> [foo](#requirement_foo) (>= 1.0)
 

--- a/format/testdata/markdown/document-WithRequired.golden
+++ b/format/testdata/markdown/document-WithRequired.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/markdown/document-WithoutHTML.golden
+++ b/format/testdata/markdown/document-WithoutHTML.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.12)
 
-- aws (>= 2.15.0)
+- aws (>= 2.15.0) (aliases: aws,aws.ident)
 
 - foo (>= 1.0)
 

--- a/format/testdata/markdown/document-WithoutHTMLWithAnchor.golden
+++ b/format/testdata/markdown/document-WithoutHTMLWithAnchor.golden
@@ -42,7 +42,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement_terraform) (>= 0.12)
 
-- <a name="requirement_aws"></a> [aws](#requirement_aws) (>= 2.15.0)
+- <a name="requirement_aws"></a> [aws](#requirement_aws) (>= 2.15.0) (aliases: aws,aws.ident)
 
 - <a name="requirement_foo"></a> [foo](#requirement_foo) (>= 1.0)
 

--- a/format/testdata/markdown/table-Base.golden
+++ b/format/testdata/markdown/table-Base.golden
@@ -38,12 +38,12 @@ followed by another line of text.
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.15.0 |
-| foo | >= 1.0 |
-| random | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| terraform | >= 0.12 | n/a |
+| aws | >= 2.15.0 | aws,aws.ident |
+| foo | >= 1.0 | n/a |
+| random | >= 2.2.0 | n/a |
 
 ## Providers
 

--- a/format/testdata/markdown/table-EscapeCharacters.golden
+++ b/format/testdata/markdown/table-EscapeCharacters.golden
@@ -38,12 +38,12 @@ followed by another line of text.
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.15.0 |
-| foo | >= 1.0 |
-| random | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| terraform | >= 0.12 | n/a |
+| aws | >= 2.15.0 | aws,aws.ident |
+| foo | >= 1.0 | n/a |
+| random | >= 2.2.0 | n/a |
 
 ## Providers
 

--- a/format/testdata/markdown/table-IndentationOfFour.golden
+++ b/format/testdata/markdown/table-IndentationOfFour.golden
@@ -38,12 +38,12 @@ followed by another line of text.
 
 #### Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.15.0 |
-| foo | >= 1.0 |
-| random | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| terraform | >= 0.12 | n/a |
+| aws | >= 2.15.0 | aws,aws.ident |
+| foo | >= 1.0 | n/a |
+| random | >= 2.2.0 | n/a |
 
 #### Providers
 

--- a/format/testdata/markdown/table-OnlyRequirements.golden
+++ b/format/testdata/markdown/table-OnlyRequirements.golden
@@ -1,8 +1,8 @@
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.15.0 |
-| foo | >= 1.0 |
-| random | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| terraform | >= 0.12 | n/a |
+| aws | >= 2.15.0 | aws,aws.ident |
+| foo | >= 1.0 | n/a |
+| random | >= 2.2.0 | n/a |

--- a/format/testdata/markdown/table-WithAnchor.golden
+++ b/format/testdata/markdown/table-WithAnchor.golden
@@ -38,12 +38,12 @@ followed by another line of text.
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.12 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 2.15.0 |
-| <a name="requirement_foo"></a> [foo](#requirement_foo) | >= 1.0 |
-| <a name="requirement_random"></a> [random](#requirement_random) | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.12 | n/a |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 2.15.0 | aws,aws.ident |
+| <a name="requirement_foo"></a> [foo](#requirement_foo) | >= 1.0 | n/a |
+| <a name="requirement_random"></a> [random](#requirement_random) | >= 2.2.0 | n/a |
 
 ## Providers
 

--- a/format/testdata/markdown/table-WithRequired.golden
+++ b/format/testdata/markdown/table-WithRequired.golden
@@ -38,12 +38,12 @@ followed by another line of text.
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.15.0 |
-| foo | >= 1.0 |
-| random | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| terraform | >= 0.12 | n/a |
+| aws | >= 2.15.0 | aws,aws.ident |
+| foo | >= 1.0 | n/a |
+| random | >= 2.2.0 | n/a |
 
 ## Providers
 

--- a/format/testdata/markdown/table-WithoutHTML.golden
+++ b/format/testdata/markdown/table-WithoutHTML.golden
@@ -38,12 +38,12 @@ followed by another line of text.
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.15.0 |
-| foo | >= 1.0 |
-| random | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| terraform | >= 0.12 | n/a |
+| aws | >= 2.15.0 | aws,aws.ident |
+| foo | >= 1.0 | n/a |
+| random | >= 2.2.0 | n/a |
 
 ## Providers
 

--- a/format/testdata/markdown/table-WithoutHTMLWithAnchor.golden
+++ b/format/testdata/markdown/table-WithoutHTMLWithAnchor.golden
@@ -38,12 +38,12 @@ followed by another line of text.
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.12 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 2.15.0 |
-| <a name="requirement_foo"></a> [foo](#requirement_foo) | >= 1.0 |
-| <a name="requirement_random"></a> [random](#requirement_random) | >= 2.2.0 |
+| Name | Version | Aliases |
+|------|---------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.12 | n/a |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 2.15.0 | aws,aws.ident |
+| <a name="requirement_foo"></a> [foo](#requirement_foo) | >= 1.0 | n/a |
+| <a name="requirement_random"></a> [random](#requirement_random) | >= 2.2.0 | n/a |
 
 ## Providers
 

--- a/format/testdata/pretty/pretty-Base.golden
+++ b/format/testdata/pretty/pretty-Base.golden
@@ -38,7 +38,7 @@ followed by another line of text.
 
 
 requirement.terraform (>= 0.12)
-requirement.aws (>= 2.15.0)
+requirement.aws (>= 2.15.0) (aliases: aws,aws.ident)
 requirement.foo (>= 1.0)
 requirement.random (>= 2.2.0)
 

--- a/format/testdata/pretty/pretty-OnlyRequirements.golden
+++ b/format/testdata/pretty/pretty-OnlyRequirements.golden
@@ -1,4 +1,4 @@
 requirement.terraform (>= 0.12)
-requirement.aws (>= 2.15.0)
+requirement.aws (>= 2.15.0) (aliases: aws,aws.ident)
 requirement.foo (>= 1.0)
 requirement.random (>= 2.2.0)

--- a/format/testdata/pretty/pretty-WithColor.golden
+++ b/format/testdata/pretty/pretty-WithColor.golden
@@ -38,7 +38,7 @@ followed by another line of text.
 
 
 [36mrequirement.terraform[0m (>= 0.12)
-[36mrequirement.aws[0m (>= 2.15.0)
+[36mrequirement.aws[0m (>= 2.15.0) (aliases: aws,aws.ident)
 [36mrequirement.foo[0m (>= 1.0)
 [36mrequirement.random[0m (>= 2.2.0)
 

--- a/format/testdata/toml/toml-Base.golden
+++ b/format/testdata/toml/toml-Base.golden
@@ -302,6 +302,7 @@ footer = "## This is an example of a footer\n\nIt looks exactly like a header, b
 [[requirements]]
   name = "aws"
   version = ">= 2.15.0"
+  aliases = "aws,aws.ident"
 
 [[requirements]]
   name = "foo"

--- a/format/testdata/toml/toml-OnlyRequirements.golden
+++ b/format/testdata/toml/toml-OnlyRequirements.golden
@@ -13,6 +13,7 @@ resources = []
 [[requirements]]
   name = "aws"
   version = ">= 2.15.0"
+  aliases = "aws,aws.ident"
 
 [[requirements]]
   name = "foo"

--- a/format/testdata/xml/xml-Base.golden
+++ b/format/testdata/xml/xml-Base.golden
@@ -324,6 +324,7 @@
     <requirement>
       <name>aws</name>
       <version>&gt;= 2.15.0</version>
+      <aliases>aws,aws.ident</aliases>
     </requirement>
     <requirement>
       <name>foo</name>

--- a/format/testdata/xml/xml-OnlyRequirements.golden
+++ b/format/testdata/xml/xml-OnlyRequirements.golden
@@ -13,6 +13,7 @@
     <requirement>
       <name>aws</name>
       <version>&gt;= 2.15.0</version>
+      <aliases>aws,aws.ident</aliases>
     </requirement>
     <requirement>
       <name>foo</name>

--- a/format/testdata/yaml/yaml-Base.golden
+++ b/format/testdata/yaml/yaml-Base.golden
@@ -271,6 +271,7 @@ requirements:
     version: '>= 0.12'
   - name: aws
     version: '>= 2.15.0'
+    aliases: aws,aws.ident
   - name: foo
     version: '>= 1.0'
   - name: random

--- a/format/testdata/yaml/yaml-OnlyRequirements.golden
+++ b/format/testdata/yaml/yaml-OnlyRequirements.golden
@@ -9,6 +9,7 @@ requirements:
     version: '>= 0.12'
   - name: aws
     version: '>= 2.15.0'
+    aliases: aws,aws.ident
   - name: foo
     version: '>= 1.0'
   - name: random

--- a/terraform/load.go
+++ b/terraform/load.go
@@ -443,12 +443,27 @@ func loadRequirements(tfmodule *tfconfig.Module) []*Requirement {
 	for _, name := range names {
 		for _, version := range tfmodule.RequiredProviders[name].VersionConstraints {
 			requirements = append(requirements, &Requirement{
-				Name:    name,
-				Version: types.String(version),
+				Name:                 name,
+				Version:              types.String(version),
+				ConfigurationAliases: getConfigurationAliases(tfmodule.RequiredProviders[name].ConfigurationAliases),
 			})
 		}
 	}
 	return requirements
+}
+
+func getConfigurationAliases(aliases []tfconfig.ProviderRef) types.String {
+	var configurationAliases []string
+
+	for _, alias := range aliases {
+		configurationAlias := alias.Name
+		if alias.Alias != "" {
+			configurationAlias += "." + alias.Alias
+		}
+		configurationAliases = append(configurationAliases, configurationAlias)
+	}
+
+	return types.String(strings.Join(configurationAliases, ","))
 }
 
 func loadResources(tfmodule *tfconfig.Module, config *print.Config) []*Resource {

--- a/terraform/load_test.go
+++ b/terraform/load_test.go
@@ -727,7 +727,7 @@ func TestLoadProviders(t *testing.T) {
 			path:     "full-example",
 			lockfile: false,
 			expected: expected{
-				providers: []string{"aws->= 2.15.0", "null-", "tls-"},
+				providers: []string{"aws->= 2.15.0", "aws.ident->= 2.15.0", "null-", "tls-"},
 			},
 		},
 		{
@@ -830,7 +830,7 @@ func TestLoadResources(t *testing.T) {
 			name: "load module resources from path",
 			path: "full-example",
 			expected: expected{
-				resources: []string{"tls_private_key.baz", "aws_caller_identity.current", "null_resource.foo"},
+				resources: []string{"tls_private_key.baz", "aws_caller_identity.current", "aws_caller_identity.ident", "null_resource.foo"},
 			},
 		},
 		{
@@ -981,7 +981,7 @@ func TestSortItems(t *testing.T) {
 				required:  []string{"A", "F"},
 				optional:  []string{"D", "B", "E", "C", "G"},
 				outputs:   []string{"C", "A", "B", "D"},
-				providers: []string{"tls", "aws", "null"},
+				providers: []string{"tls", "aws", "aws", "null"},
 			},
 		},
 		{
@@ -994,7 +994,7 @@ func TestSortItems(t *testing.T) {
 				required:  []string{"A", "F"},
 				optional:  []string{"D", "B", "E", "C", "G"},
 				outputs:   []string{"C", "A", "B", "D"},
-				providers: []string{"tls", "aws", "null"},
+				providers: []string{"tls", "aws", "aws", "null"},
 			},
 		},
 		{
@@ -1007,7 +1007,7 @@ func TestSortItems(t *testing.T) {
 				required:  []string{"A", "F"},
 				optional:  []string{"D", "B", "E", "C", "G"},
 				outputs:   []string{"C", "A", "B", "D"},
-				providers: []string{"tls", "aws", "null"},
+				providers: []string{"tls", "aws", "aws", "null"},
 			},
 		},
 		{
@@ -1020,7 +1020,7 @@ func TestSortItems(t *testing.T) {
 				required:  []string{"A", "F"},
 				optional:  []string{"B", "C", "D", "E", "G"},
 				outputs:   []string{"A", "B", "C", "D"},
-				providers: []string{"aws", "null", "tls"},
+				providers: []string{"aws", "aws", "null", "tls"},
 			},
 		},
 		{
@@ -1033,7 +1033,7 @@ func TestSortItems(t *testing.T) {
 				required:  []string{"A", "F"},
 				optional:  []string{"B", "C", "D", "E", "G"},
 				outputs:   []string{"A", "B", "C", "D"},
-				providers: []string{"aws", "null", "tls"},
+				providers: []string{"aws", "aws", "null", "tls"},
 			},
 		},
 		{
@@ -1046,7 +1046,7 @@ func TestSortItems(t *testing.T) {
 				required:  []string{"A", "F"},
 				optional:  []string{"G", "B", "C", "D", "E"},
 				outputs:   []string{"A", "B", "C", "D"},
-				providers: []string{"aws", "null", "tls"},
+				providers: []string{"aws", "aws", "null", "tls"},
 			},
 		},
 	}

--- a/terraform/requirement.go
+++ b/terraform/requirement.go
@@ -16,6 +16,7 @@ import (
 
 // Requirement represents a requirement for Terraform module.
 type Requirement struct {
-	Name    string       `json:"name" toml:"name" xml:"name" yaml:"name"`
-	Version types.String `json:"version" toml:"version" xml:"version" yaml:"version"`
+	Name                 string       `json:"name" toml:"name" xml:"name" yaml:"name"`
+	Version              types.String `json:"version" toml:"version" xml:"version" yaml:"version"`
+	ConfigurationAliases types.String `json:"aliases,omitempty" toml:"aliases,omitempty" xml:"aliases,omitempty" yaml:"aliases,omitempty"`
 }

--- a/terraform/testdata/full-example/main.tf
+++ b/terraform/testdata/full-example/main.tf
@@ -11,7 +11,13 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = ">= 2.15.0"
+    aws = {
+      version = ">= 2.15.0"
+      configuration_aliases = [
+        aws,
+        aws.ident
+      ]
+    }
   }
 }
 
@@ -19,6 +25,10 @@ resource "tls_private_key" "baz" {}
 
 data "aws_caller_identity" "current" {
   provider = "aws"
+}
+
+data "aws_caller_identity" "ident" {
+    provider = "aws.ident"
 }
 
 # terraform-docs-ignore


### PR DESCRIPTION
### Description of your changes

Expose the `configuration_aliases` associated with `required_providers` as a comma separated list of aliases within the requirements section of terraform-docs.

Fixes #819 

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

I have built this locally and executed it on a subset of my terraform modules. It present me with the expected comma separated list of aliases in the requirements section when `configuration_aliases` are defined.

I have tested all of the supported terraform-docs output formats.

[contribution process]: https://git.io/JtEzg
