### PR TITLE
Fix output template formatting

### DIFF
--- a/print/config.go
+++ b/print/config.go
@@ -205,7 +205,7 @@ const (
 
 // Output to file template and modes.
 var (
-	OutputTemplate = fmt.Sprintf("%s\n%s\n%s", OutputBeginComment, OutputContent, OutputEndComment)
+	OutputTemplate = fmt.Sprintf("%s\n%s\n%s\n", OutputBeginComment, OutputContent, OutputEndComment)
 	OutputModes    = strings.Join([]string{OutputModeInject, OutputModeReplace}, ", ")
 )
 


### PR DESCRIPTION
### Description of your changes

This pull request fixes an issue where the output template was missing a newline at the end of the file. This caused file validation tools, such as `pre-commit`, to fail their checks. Adding the newline ensures compatibility with these tools and improves overall file formatting compliance.

<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

The change was tested by generating the output template and validating it using `pre-commit` to ensure no file validation errors occur. Additionally, all existing tests were run to confirm that the change does not introduce any regressions.