### PR TITLE
Add winget as a Windows installation option

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -28,6 +28,12 @@ brew install terraform-docs/tap/terraform-docs
 
 If you are a Windows user:
 
+### winget
+
+```bash
+winget install -e -h -s winget --id Terraform-docs.Terraform-docs
+```
+
 ### Scoop
 
 You can use [Scoop].


### PR DESCRIPTION
### Description of your changes

Add winget as an option to install Terraform-docs to the installation doc.

I have:

- [ ] Read and followed terraform-docs' [contribution process].
- [ ] All tests pass when I run `make test`.

### How has this code been tested

N/A (docs only)