### PR TITLE
Fix typo in markdown-table.md

### DIFF
--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -33,7 +33,7 @@ terraform-docs markdown table [PATH] [flags]
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-empty                  hide empty sections (default false)
-      --html                        use HTML tags in genereted output (default true)
+      --html                        use HTML tags in generated output (default true)
       --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)


### PR DESCRIPTION

### Description of your changes

Fix typo in markdown-table.md

<!-- Fixes # -->

I have:

- [X ] Read and followed terraform-docs' [contribution process].
- [N/A] All tests pass when I run `make test`.

Update reference docs to fix a minor spelling typo.

### How has this code been tested
N/A