### PR TITLE
 use docker_manifests to push multiarch image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 project_name: terraform-docs
 
+version: 2
+
 builds:
   - main: .
     env:
@@ -86,17 +88,27 @@ dockers:
       - "quay.io/terraform-docs/terraform-docs:{{ .RawVersion }}-amd64"
     use: buildx
     build_flag_templates:
-    - "--pull"
-    - "--platform=linux/amd64"
+      - "--pull"
+      - "--platform=linux/amd64"
   - dockerfile: scripts/release/Dockerfile
     image_templates:
       - "quay.io/terraform-docs/terraform-docs:latest-arm64"
       - "quay.io/terraform-docs/terraform-docs:{{ .RawVersion }}-arm64"
     use: buildx
     build_flag_templates:
-    - "--pull"
-    - "--platform=linux/arm64"
+      - "--pull"
+      - "--platform=linux/arm64"
     goarch: arm64
+
+docker_manifests:
+  - name_template: "quay.io/terraform-docs/terraform-docs:{{ .RawVersion }}"
+    image_templates:
+      - "quay.io/terraform-docs/terraform-docs:{{ .RawVersion }}-amd64"
+      - "quay.io/terraform-docs/terraform-docs:{{ .RawVersion }}-arm64"
+  - name_template: "quay.io/terraform-docs/terraform-docs:latest"
+    image_templates:
+      - "quay.io/terraform-docs/terraform-docs:latest-amd64"
+      - "quay.io/terraform-docs/terraform-docs:latest-arm64"
 
 brews:
   - repository:


### PR DESCRIPTION
### Description of your changes

Fixes #887 : use docker_manifests to push multiarch image manifest based on name templating

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

Tested with
```
goreleaser release --skip=publish --snapshot --clean
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=db73fe8178d20b69d83713481798f13d1097068b branch=patch-1 current_tag=v0.21.0 previous_tag=v0.20.0 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
    • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
    • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
    • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
  • snapshotting
    • building snapshot...                           version=v0.21.0-dev
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/terraform-docs_windows_arm64_v8.0/terraform-docs.exe
    • building                                       binary=dist/terraform-docs_darwin_amd64_v1/terraform-docs
    • building                                       binary=dist/terraform-docs_linux_arm64_v8.0/terraform-docs
    • building                                       binary=dist/terraform-docs_freebsd_arm64_v8.0/terraform-docs
    • building                                       binary=dist/terraform-docs_windows_amd64_v1/terraform-docs.exe
    • building                                       binary=dist/terraform-docs_linux_amd64_v1/terraform-docs
    • building                                       binary=dist/terraform-docs_freebsd_amd64_v1/terraform-docs
    • building                                       binary=dist/terraform-docs_linux_arm_6/terraform-docs
    • building                                       binary=dist/terraform-docs_freebsd_arm_6/terraform-docs
    • building                                       binary=dist/terraform-docs_darwin_arm64_v8.0/terraform-docs
  • archives
    • archiving                                      name=dist/terraform-docs-v0.21.0-darwin-arm64.tar.gz
    • archiving                                      name=dist/terraform-docs-v0.21.0-windows-amd64.zip
    • archiving                                      name=dist/terraform-docs-v0.21.0-freebsd-amd64.tar.gz
    • archiving                                      name=dist/terraform-docs-v0.21.0-freebsd-arm.tar.gz
    • archiving                                      name=dist/terraform-docs-v0.21.0-linux-arm64.tar.gz
    • archiving                                      name=dist/terraform-docs-v0.21.0-freebsd-arm64.tar.gz
    • archiving                                      name=dist/terraform-docs-v0.21.0-linux-arm.tar.gz
    • archiving                                      name=dist/terraform-docs-v0.21.0-windows-arm64.zip
    • archiving                                      name=dist/terraform-docs-v0.21.0-darwin-amd64.tar.gz
    • archiving                                      name=dist/terraform-docs-v0.21.0-linux-amd64.tar.gz
  • calculating checksums
  • homebrew formula
    • guessing install                               install=[bin.install "terraform-docs"]
    • guessing install                               install=[bin.install "terraform-docs"]
    • guessing install                               install=[bin.install "terraform-docs"]
    • guessing install                               install=[bin.install "terraform-docs"]
    • guessing install                               install=[bin.install "terraform-docs"]
    • writing                                        formula=dist/homebrew/terraform-docs.rb
  • scoop manifests
    • writing                                        manifest=dist/scoop/terraform-docs.json
  • docker images
    • building docker image                          image=quay.io/terraform-docs/terraform-docs:latest-arm64
    • building docker image                          image=quay.io/terraform-docs/terraform-docs:latest-amd64
  • writing artifacts metadata
  • you are using deprecated options, check the output above for details
  • release succeeded after 5s
  • thanks for using GoReleaser!
```

