### PR TITLE
feat: print unified diff when file content changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/cli/writer.go
+++ b/internal/cli/writer.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/aymanbagabas/go-udiff"
+
 	"github.com/terraform-docs/terraform-docs/print"
 )
 
@@ -159,15 +161,21 @@ func (fw *fileWriter) inject(filename string, content string, generated string) 
 // write the content to io.Writer. If no io.Writer is available,
 // it will be written to 'filename'.
 func (fw *fileWriter) write(filename string, p []byte) (int, error) {
+	// read the file to provide diff or check
+	f, err := os.ReadFile(filepath.Clean(filename))
+	if err != nil && !os.IsNotExist(err) {
+		return 0, err
+	}
+
 	// if run in check mode return exit 1
 	if fw.check {
-		f, err := os.ReadFile(filepath.Clean(filename))
 		if err != nil {
 			return 0, err
 		}
 
 		// check for changes and print changed file
 		if !bytes.Equal(f, p) {
+			printDiff(filename, f, p)
 			return 0, fmt.Errorf("%s is out of date", filename)
 		}
 
@@ -179,6 +187,15 @@ func (fw *fileWriter) write(filename string, p []byte) (int, error) {
 		return fw.writer.Write(p)
 	}
 
+	if err == nil && !bytes.Equal(f, p) {
+		printDiff(filename, f, p)
+	}
+
 	fmt.Printf("%s updated successfully\n", filename)
 	return len(p), os.WriteFile(filename, p, 0644)
+}
+
+func printDiff(file string, oldContent, newContent []byte) {
+	d := udiff.Unified(file, file, string(oldContent), string(newContent))
+	fmt.Print(d)
 }

--- a/internal/cli/writer_diff_test.go
+++ b/internal/cli/writer_diff_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2021 The terraform-docs Authors.
+
+Licensed under the MIT license (the "License"); you may not
+use this file except in compliance with the License.
+
+You may obtain a copy of the License at the LICENSE file in
+the root directory of this source tree.
+*/
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/terraform-docs/terraform-docs/print"
+)
+
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestFileWriter_Diff(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test-diff.txt")
+	initialContent := []byte("line 1\nline 2\nline 3\n")
+	newContent := []byte("line 1\nline 2 changed\nline 3\n")
+
+	// Create initial file
+	err := os.WriteFile(filePath, initialContent, 0644)
+	assert.NoError(t, err)
+
+	t.Run("CheckMode_PrintsDiff", func(t *testing.T) {
+		fw := &fileWriter{
+			file:  filePath,
+			dir:   "",
+			check: true,
+			mode:  print.OutputModeReplace,
+		}
+
+		output := captureStdout(func() {
+			_, err := fw.Write(newContent)
+			assert.Error(t, err)
+			assert.Equal(t, fmt.Sprintf("%s is out of date", filePath), err.Error())
+		})
+
+		assert.Contains(t, output, "--- "+filePath)
+		assert.Contains(t, output, "+++ "+filePath)
+		assert.Contains(t, output, "-line 2")
+		assert.Contains(t, output, "+line 2 changed")
+	})
+
+	t.Run("WriteMode_PrintsDiff_OnOverwrite", func(t *testing.T) {
+		// Reset file content
+		err := os.WriteFile(filePath, initialContent, 0644)
+		assert.NoError(t, err)
+
+		fw := &fileWriter{
+			file:  filePath,
+			dir:   "",
+			check: false,
+			mode:  print.OutputModeReplace,
+		}
+
+		output := captureStdout(func() {
+			_, err := fw.Write(newContent)
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "--- "+filePath)
+		assert.Contains(t, output, "+++ "+filePath)
+		assert.Contains(t, output, "-line 2")
+		assert.Contains(t, output, "+line 2 changed")
+		assert.Contains(t, output, filePath+" updated successfully")
+	})
+
+	t.Run("WriteMode_NoDiff_OnIdentical", func(t *testing.T) {
+		// Reset file content
+		err := os.WriteFile(filePath, initialContent, 0644)
+		assert.NoError(t, err)
+
+		fw := &fileWriter{
+			file:  filePath,
+			dir:   "",
+			check: false,
+			mode:  print.OutputModeReplace,
+		}
+
+		output := captureStdout(func() {
+			_, err := fw.Write(initialContent)
+			assert.NoError(t, err)
+		})
+
+		assert.NotContains(t, output, "--- ")
+		assert.NotContains(t, output, "+++ ")
+		assert.Contains(t, output, filePath+" updated successfully")
+	})
+}


### PR DESCRIPTION
Currently, when running in --output-check mode (like in the GitHub Action), the tool only reports that a file is out of date without showing what specifically changed. This makes debugging CI failures difficult.

This change adds a unified diff output to stdout whenever:
1. Validation fails in --output-check mode.
2. A file is successfully updated in overwrite mode (providing visibility into changes).

### Description of your changes

Currently, when running in --output-check mode (like in the GitHub Action), the tool only reports that a file is out of date without showing what specifically changed. This makes debugging CI failures difficult.

This change adds a unified diff output to stdout whenever:
1. Validation fails in --output-check mode.
2. A file is successfully updated in overwrite mode (providing visibility into changes).

### How has this code been tested

I have added a new test file `writer_diff_test.go` which specifically targets the unified diff logic. The tests cover three main scenarios:
- Check mode
- Overwrite mode
- No changes

I also manually verified this by modifying a generated documentation file in the examples directory and running `terraform-docs` against it. I configmred that the stdout contained the expected diff output before the success/failure message. 


Disclaimer: AI assisted me to create this contribution. 



[contribution process]: https://git.io/JtEzg
