### PR TITLE
docs: clarify container image registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,12 @@ Check [`output`] configuration for more details and examples.
 
 ### Using docker
 
+> **Note:** terraform-docs container images are published on Quay  
+> (`quay.io/terraform-docs/terraform-docs`). Docker Hub is not used.
+
 terraform-docs can be run as a container by mounting a directory with `.tf`
 files in it and run the following command:
+
 
 ```bash
 docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.21.0 markdown /terraform-docs


### PR DESCRIPTION
Clarifies that terraform-docs Docker images are published on Quay and not Docker Hub,
to avoid confusion when pulling tagged releases.

Related to #887
