### PR TITLE
Add processor architecture suffix to image tag in docker install commands

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -47,18 +47,28 @@ choco install terraform-docs
 
 ## Docker
 
-terraform-docs can be run as a container by mounting a directory with `.tf`
+terraform-docs can be run as a container on both `amd64` and `arm64` machines by mounting a directory with `.tf`
 files in it and run the following command:
 
 ```bash
-docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.21.0 markdown /terraform-docs
+# specify IMAGE_TAG-ARCHITECTURE
+
+# amd64
+docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.21.0-amd64 markdown /terraform-docs
+
+# arm64
+docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.21.0-arm64 markdown /terraform-docs
 ```
 
 If `output.file` is not enabled for this module, generated output can be redirected
 back to a file:
 
 ```bash
-docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.21.0 markdown /terraform-docs > doc.md
+# amd64
+docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.21.0-amd64  markdown /terraform-docs > doc.md
+
+# arm64
+docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.21.0-amd64  markdown /terraform-docs > doc.md
 ```
 
 {{< alert type="primary" >}}


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

On the [installation](https://terraform-docs.io/user-guide/installation/#docker) page of the User Guide - there are commands for running `terraform-docs` in a Docker container

Based on the Quay repository here - https://quay.io/repository/terraform-docs/terraform-docs?tab=tags , as of `0.21.0`, these images are built with a suffix for processor architecture (`-amd64` and `-arm64`) 

I don't have all the docs here memorized 😆 so I'm not sure the best way to phrase something like this, so I added a few words in the instructions, and comments/commands in the code blocks 

If this is not the best way, then please let me know! (or a more experienced contributor feel free to take this over the finish line!) 

**ALSO**

I was unsure if we should add the same clarification to the block below (located on the same page)

```md
{{< alert type="primary" >}}
Docker tag `latest` refers to _latest_ stable released version and `edge` refers
to HEAD of `master` at any given point in time. And any named version tags are
identical to the official GitHub releases without leading `v`.
{{< /alert >}}
```

 changing to something like

```md
Docker tag `latest-amd64` / `latest-arm64`  refers to _latest_ stable released version and `edge` refers
<etc, etc> 

```

Fixes #887 

<!-- Fixes # -->

I have:

- [X] Read and followed terraform-docs' [contribution process].
- [X] All tests pass when I run `make test`.

### How has this code been tested

No tests, this is a docs change (if there is a test I should perform, happy to do so!) 

[contribution process]: https://git.io/JtEzg
