### PR TITLE
Open tofu dynamic providers

### DIFF
--- a/terraform/load.go
+++ b/terraform/load.go
@@ -22,7 +22,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/terraform-docs/terraform-config-inspect/tfconfig"
 	"github.com/terraform-docs/terraform-docs/internal/reader"
@@ -49,9 +52,96 @@ func LoadWithOptions(config *print.Config) (*Module, error) {
 func loadModule(path string) (*tfconfig.Module, error) {
 	module, diag := tfconfig.LoadModule(path)
 	if diag != nil && diag.HasErrors() {
-		return nil, diag
+		// Filter out "Invalid provider reference" errors which can happen with OpenTofu 'for_each' in providers
+		var filteredDiags tfconfig.Diagnostics
+		for i := range diag {
+			if diag[i].Severity == tfconfig.DiagError && (diag[i].Summary == "Invalid provider reference" || strings.Contains(diag[i].Detail, "Provider argument requires a provider name followed by an optional alias")) {
+				continue
+			}
+			filteredDiags = append(filteredDiags, diag[i])
+		}
+		if filteredDiags.HasErrors() {
+			return nil, filteredDiags
+		}
+	}
+	if err := fixOpenTofuProviders(module); err != nil {
+		return nil, err
 	}
 	return module, nil
+}
+
+func fixOpenTofuProviders(module *tfconfig.Module) error {
+	resources := []map[string]*tfconfig.Resource{module.ManagedResources, module.DataResources}
+	parser := hclparse.NewParser()
+
+	// cache parsed files to avoid re-reading/re-parsing
+	files := make(map[string]*hcl.File)
+
+	for _, resourceMap := range resources {
+		for _, r := range resourceMap {
+			// Check if provider is missing or default (empty name/alias issues)
+			// If r.Provider.Name is empty, it's definitely broken (since resourceTypeDefaultProviderName always returns something).
+			if r.Provider.Name != "" {
+				continue
+			}
+			f, err := getParsedFile(parser, r.Pos.Filename, files)
+			if err != nil {
+				return err
+			}
+			if f == nil {
+				continue
+			}
+			if name, alias, ok := findProviderInFile(f, r.Pos.Line); ok {
+				r.Provider.Name = name
+				r.Provider.Alias = alias
+			}
+		}
+	}
+	return nil
+}
+
+func getParsedFile(parser *hclparse.Parser, filename string, files map[string]*hcl.File) (*hcl.File, error) {
+	if f, ok := files[filename]; ok {
+		return f, nil
+	}
+	b, err := os.ReadFile(filepath.Clean(filename))
+	if err != nil {
+		return nil, err
+	}
+	f, _ := parser.ParseHCL(b, filename)
+	files[filename] = f
+	return f, nil
+}
+
+func findProviderInFile(f *hcl.File, line int) (string, string, bool) {
+	for _, b := range f.Body.(*hclsyntax.Body).Blocks {
+		if b.DefRange().Start.Line != line {
+			continue
+		}
+		attr, ok := b.Body.Attributes["provider"]
+		if !ok {
+			return "", "", false
+		}
+		expr := attr.Expr
+		if idxExpr, ok := expr.(*hclsyntax.IndexExpr); ok {
+			expr = idxExpr.Collection
+		}
+
+		// Try to get traversal
+		traversal, diags := hcl.AbsTraversalForExpr(expr)
+		if diags.HasErrors() || len(traversal) == 0 {
+			return "", "", false
+		}
+		providerName := traversal.RootName()
+		alias := ""
+		if len(traversal) > 1 {
+			if getAttr, ok := traversal[1].(hcl.TraverseAttr); ok {
+				alias = getAttr.Name
+			}
+		}
+		return providerName, alias, true
+	}
+	return "", "", false
 }
 
 func loadModuleItems(tfmodule *tfconfig.Module, config *print.Config) (*Module, error) {

--- a/terraform/load_test.go
+++ b/terraform/load_test.go
@@ -1092,3 +1092,26 @@ func TestSortItems(t *testing.T) {
 		})
 	}
 }
+func TestLoadOpenTofuProviders(t *testing.T) {
+	assert := assert.New(t)
+
+	config := print.NewConfig()
+	config.ModuleRoot = filepath.Join("testdata", "opentofu-for-each")
+
+	module, err := LoadWithOptions(config)
+	assert.Nil(err)
+	assert.Equal(true, module.HasProviders())
+
+	found := false
+	for _, p := range module.Providers {
+		if p.Name == "aws" && string(p.Alias) == "main" {
+			found = true
+			break
+		}
+	}
+	assert.True(found, "aws.main provider should be found")
+
+	assert.Equal(true, module.HasResources())
+	assert.Equal(1, len(module.Resources))
+	assert.Equal("aws", module.Resources[0].ProviderName)
+}

--- a/terraform/testdata/opentofu-for-each/main.tf
+++ b/terraform/testdata/opentofu-for-each/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  for_each = toset(["us-east-1"])
+  alias    = "main"
+}
+
+data "aws_caller_identity" "current" {
+  provider = aws.main["us-east-1"]
+}


### PR DESCRIPTION
I was reading about the issue and I was affected by this myself. This PR tries to solve the "delicate" problem of OpenTofu for_each provider creating a fatal error in the parsing. Maybe not the best solution but I hope that a solution nevertheless. I'm not too good with **go** so I helped myself with an "assistant" to help me complete the task.

I'm aware that this fix maybe doesn't belong here but it would allow a lot of projects (like mine) to continue using your great tool terraform-docs even when using dynamic providers with OpenTofu
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Added logic to loadModule to ignore specific "Invalid provider reference" errors that occur during the initial HCL load.
Provider Fix (fixOpenTofuProviders): 
Implemented a function that:

- Iterates through resources in the loaded module.
- If a resource is missing its provider name (due to the parsing error), it re-parses the source file locally.
- It correctly interprets the for_each index expression (e.g., aws.main[each.key]) to extract the provider name and alias.
- Updates the resource in the module with the correct provider information.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

<!-- Fixes # -->
Fixes #895 
I have:

- [X] Read and followed terraform-docs' [contribution process].
- [X] All tests pass when I run `make test`.

### How has this code been tested
 
Added a new test case TestLoadOpenTofuProviders in terraform/load_test.go and corresponding test data in terraform/testdata/opentofu-for-each/.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
