### PR TITLE
feat: make registry URL configurable for OpenTofu and private registries

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&config.OutputValues.From, "output-values-from", "", "inject output values from file into outputs (default \"\")")
 
 	cmd.PersistentFlags().BoolVar(&config.Settings.ReadComments, "read-comments", true, "use comments as description when description is empty")
+	cmd.PersistentFlags().StringVar(&config.Settings.RegistryURL, "registry-url", "", "registry URL template for resource links; supports Go template variables: {{.Namespace}}, {{.Provider}}, {{.Version}}, {{.VersionWithV}}, {{.Kind}}, {{.Type}} (default Terraform registry)")
 
 	// formatter subcommands
 	cmd.AddCommand(asciidoc.NewCommand(runtime, config))

--- a/internal/cli/mappings.go
+++ b/internal/cli/mappings.go
@@ -39,6 +39,7 @@ var flagMappings = map[string]string{
 	"escape":        "settings.escape",
 	"indent":        "settings.indent",
 	"read-comments": "settings.read-comments",
+	"registry-url":  "settings.registry-url",
 	"required":      "settings.required",
 	"sensitive":     "settings.sensitive",
 	"type":          "settings.type",

--- a/print/config.go
+++ b/print/config.go
@@ -381,20 +381,21 @@ func (s *sort) validate() error {
 }
 
 type settings struct {
-	Anchor       bool `mapstructure:"anchor"`
-	AtxClosed    bool `mapstructure:"atx-closed"`
-	Color        bool `mapstructure:"color"`
-	Default      bool `mapstructure:"default"`
-	Description  bool `mapstructure:"description"`
-	Escape       bool `mapstructure:"escape"`
-	HideEmpty    bool `mapstructure:"hide-empty"`
-	HTML         bool `mapstructure:"html"`
-	Indent       int  `mapstructure:"indent"`
-	LockFile     bool `mapstructure:"lockfile"`
-	ReadComments bool `mapstructure:"read-comments"`
-	Required     bool `mapstructure:"required"`
-	Sensitive    bool `mapstructure:"sensitive"`
-	Type         bool `mapstructure:"type"`
+	Anchor       bool   `mapstructure:"anchor"`
+	AtxClosed    bool   `mapstructure:"atx-closed"`
+	Color        bool   `mapstructure:"color"`
+	Default      bool   `mapstructure:"default"`
+	Description  bool   `mapstructure:"description"`
+	Escape       bool   `mapstructure:"escape"`
+	HideEmpty    bool   `mapstructure:"hide-empty"`
+	HTML         bool   `mapstructure:"html"`
+	Indent       int    `mapstructure:"indent"`
+	LockFile     bool   `mapstructure:"lockfile"`
+	ReadComments bool   `mapstructure:"read-comments"`
+	RegistryURL  string `mapstructure:"registry-url"`
+	Required     bool   `mapstructure:"required"`
+	Sensitive    bool   `mapstructure:"sensitive"`
+	Type         bool   `mapstructure:"type"`
 }
 
 func defaultSettings() settings {

--- a/terraform/load.go
+++ b/terraform/load.go
@@ -494,6 +494,7 @@ func loadResources(tfmodule *tfconfig.Module, config *print.Config) []*Resource 
 				ProviderSource: source,
 				Version:        types.String(version),
 				Description:    types.String(description),
+				RegistryURL:    config.Settings.RegistryURL,
 				Position: Position{
 					Filename: r.Pos.Filename,
 					Line:     r.Pos.Line,

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -11,9 +11,10 @@ the root directory of this source tree.
 package terraform
 
 import (
-	"fmt"
+	"bytes"
 	"sort"
 	"strings"
+	gotemplate "text/template"
 
 	"github.com/terraform-docs/terraform-docs/internal/types"
 )
@@ -28,7 +29,10 @@ type Resource struct {
 	Version        types.String `json:"version" toml:"version" xml:"version" yaml:"version"`
 	Description    types.String `json:"description" toml:"description" xml:"description" yaml:"description"`
 	Position       Position     `json:"-" toml:"-" xml:"-" yaml:"-"`
+	RegistryURL    string       `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
+
+const defaultRegistryURLTemplate = "https://registry.terraform.io/providers/{{.Namespace}}/{{.Provider}}/{{.Version}}/docs/{{.Kind}}/{{.Type}}"
 
 // Spec returns the resource spec addresses a specific resource in the config.
 // It takes the form: resource_type.resource_name[resource index]
@@ -50,7 +54,8 @@ func (r *Resource) GetMode() string {
 	}
 }
 
-// URL returns a best guess at the URL for resource documentation
+// URL returns the URL for resource documentation using the configured registry URL template.
+// If no custom template is set, it defaults to the Terraform public registry.
 func (r *Resource) URL() string {
 	kind := ""
 	switch r.Mode {
@@ -65,7 +70,51 @@ func (r *Resource) URL() string {
 	if strings.Count(r.ProviderSource, "/") > 1 {
 		return ""
 	}
-	return fmt.Sprintf("https://registry.terraform.io/providers/%s/%s/docs/%s/%s", r.ProviderSource, r.Version, kind, r.Type)
+
+	parts := strings.SplitN(r.ProviderSource, "/", 2)
+	namespace := parts[0]
+	provider := parts[0]
+	if len(parts) == 2 {
+		provider = parts[1]
+	}
+
+	version := string(r.Version)
+	versionWithV := version
+	if version != "latest" && version != "" {
+		versionWithV = "v" + version
+	}
+
+	urlTemplate := r.RegistryURL
+	if urlTemplate == "" {
+		urlTemplate = defaultRegistryURLTemplate
+	}
+
+	tpl, err := gotemplate.New("registry-url").Parse(urlTemplate)
+	if err != nil {
+		return ""
+	}
+
+	data := struct {
+		Namespace    string
+		Provider     string
+		Version      string
+		VersionWithV string
+		Kind         string
+		Type         string
+	}{
+		Namespace:    namespace,
+		Provider:     provider,
+		Version:      version,
+		VersionWithV: versionWithV,
+		Kind:         kind,
+		Type:         r.Type,
+	}
+
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, data); err != nil {
+		return ""
+	}
+	return buf.String()
 }
 
 func sortResourcesByType(x []*Resource) {

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -81,7 +81,7 @@ func TestResourceURL(t *testing.T) {
 		resource    Resource
 		expectValue string
 	}{
-		"Generic URL construction": {
+		"Default Terraform registry": {
 			resource: Resource{
 				Type:           "private_key",
 				ProviderName:   "tls",
@@ -91,6 +91,16 @@ func TestResourceURL(t *testing.T) {
 			},
 			expectValue: "https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key",
 		},
+		"Default Terraform registry data source": {
+			resource: Resource{
+				Type:           "caller_identity",
+				ProviderName:   "aws",
+				ProviderSource: "hashicorp/aws",
+				Mode:           "data",
+				Version:        types.String("latest"),
+			},
+			expectValue: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity",
+		},
 		"Unable to construct URL": {
 			resource: Resource{
 				Type:           "custom",
@@ -98,6 +108,50 @@ func TestResourceURL(t *testing.T) {
 				ProviderSource: "http://nih.tld/some/path/to/provider/source",
 				Mode:           "managed",
 				Version:        types.String("latest"),
+			},
+			expectValue: "",
+		},
+		"OpenTofu registry with VersionWithV on specific version": {
+			resource: Resource{
+				Type:           "instance",
+				ProviderName:   "aws",
+				ProviderSource: "hashicorp/aws",
+				Mode:           "managed",
+				Version:        types.String("5.65.0"),
+				RegistryURL:    "https://search.opentofu.org/provider/{{.Namespace}}/{{.Provider}}/{{.VersionWithV}}/docs/{{.Kind}}/{{.Type}}",
+			},
+			expectValue: "https://search.opentofu.org/provider/hashicorp/aws/v5.65.0/docs/resources/instance",
+		},
+		"OpenTofu registry with VersionWithV on latest": {
+			resource: Resource{
+				Type:           "instance",
+				ProviderName:   "aws",
+				ProviderSource: "hashicorp/aws",
+				Mode:           "managed",
+				Version:        types.String("latest"),
+				RegistryURL:    "https://search.opentofu.org/provider/{{.Namespace}}/{{.Provider}}/{{.VersionWithV}}/docs/{{.Kind}}/{{.Type}}",
+			},
+			expectValue: "https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/instance",
+		},
+		"Custom private registry": {
+			resource: Resource{
+				Type:           "bucket",
+				ProviderName:   "aws",
+				ProviderSource: "hashicorp/aws",
+				Mode:           "managed",
+				Version:        types.String("4.0.0"),
+				RegistryURL:    "https://registry.company.com/providers/{{.Namespace}}/{{.Provider}}/{{.Version}}/docs/{{.Kind}}/{{.Type}}",
+			},
+			expectValue: "https://registry.company.com/providers/hashicorp/aws/4.0.0/docs/resources/bucket",
+		},
+		"Invalid template returns empty string": {
+			resource: Resource{
+				Type:           "instance",
+				ProviderName:   "aws",
+				ProviderSource: "hashicorp/aws",
+				Mode:           "managed",
+				Version:        types.String("latest"),
+				RegistryURL:    "https://registry.example.com/{{.Invalid",
 			},
 			expectValue: "",
 		},


### PR DESCRIPTION
Adds a `registry-url` setting (and `--registry-url` CLI flag) that accepts a Go template string for customizing resource documentation links. Supports template vars: {{.Namespace}}, {{.Provider}}, {{.Version}}, {{.VersionWithV}}, {{.Kind}}, {{.Type}}. Defaults to the Terraform public registry (no behavior change).

Fixes #812

<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/JtEzg if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

<!-- Fixes # -->

I have:

- [ ] Read and followed terraform-docs' [contribution process].
- [ ] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
