### PR TITLE
fix: deterministic sorting for providers

### DIFF
--- a/terraform/load.go
+++ b/terraform/load.go
@@ -402,7 +402,12 @@ func loadProviders(tfmodule *tfconfig.Module, config *print.Config) []*Provider 
 			}
 
 			key := fmt.Sprintf("%s.%s", r.Provider.Name, r.Provider.Alias)
-			if _, ok := discovered[key]; ok {
+			if existing, ok := discovered[key]; ok {
+				// keep the earliest position across all resources of this provider
+				if r.Pos.Filename < existing.Position.Filename ||
+					(r.Pos.Filename == existing.Position.Filename && r.Pos.Line < existing.Position.Line) {
+					existing.Position = Position{Filename: r.Pos.Filename, Line: r.Pos.Line}
+				}
 				continue
 			}
 
@@ -418,9 +423,15 @@ func loadProviders(tfmodule *tfconfig.Module, config *print.Config) []*Provider 
 		}
 	}
 
+	keys := make([]string, 0, len(discovered))
+	for key := range discovered {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
 	providers := make([]*Provider, 0, len(discovered))
-	for _, provider := range discovered {
-		providers = append(providers, provider)
+	for _, key := range keys {
+		providers = append(providers, discovered[key])
 	}
 
 	return providers
@@ -502,9 +513,15 @@ func loadResources(tfmodule *tfconfig.Module, config *print.Config) []*Resource 
 		}
 	}
 
+	resourceKeys := make([]string, 0, len(discovered))
+	for key := range discovered {
+		resourceKeys = append(resourceKeys, key)
+	}
+	sort.Strings(resourceKeys)
+
 	resources := make([]*Resource, 0, len(discovered))
-	for _, resource := range discovered {
-		resources = append(resources, resource)
+	for _, key := range resourceKeys {
+		resources = append(resources, discovered[key])
 	}
 	return resources
 }

--- a/terraform/load_test.go
+++ b/terraform/load_test.go
@@ -885,6 +885,18 @@ func TestLoadProvidersDeterministic(t *testing.T) {
 			sortenabled: true,
 			expected:    []string{"aws", "tls"},
 		},
+		{
+			name:        "position sort preserves file order when providers appear in non-alphabetical order",
+			path:        "providers-non-alpha-order",
+			sortenabled: false,
+			expected:    []string{"tls", "aws"},
+		},
+		{
+			name:        "name sort returns alphabetical order regardless of file order",
+			path:        "providers-non-alpha-order",
+			sortenabled: true,
+			expected:    []string{"aws", "tls"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/terraform/load_test.go
+++ b/terraform/load_test.go
@@ -866,6 +866,81 @@ func TestLoadResources(t *testing.T) {
 	}
 }
 
+func TestLoadProvidersDeterministic(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		sortenabled bool
+		expected    []string
+	}{
+		{
+			name:        "position sort is deterministic when a provider has multiple resources",
+			path:        "multi-provider-resources",
+			sortenabled: false,
+			expected:    []string{"aws", "tls"},
+		},
+		{
+			name:        "name sort is deterministic when a provider has multiple resources",
+			path:        "multi-provider-resources",
+			sortenabled: true,
+			expected:    []string{"aws", "tls"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			config := print.NewConfig()
+			module, err := loadModule(filepath.Join("testdata", tt.path))
+			assert.Nil(err)
+
+			for i := 0; i < 100; i++ {
+				pp := loadProviders(module, config)
+				providers(pp).sort(tt.sortenabled, "")
+
+				actual := make([]string, len(pp))
+				for j, p := range pp {
+					actual[j] = p.FullName()
+				}
+				assert.Equal(tt.expected, actual, "iteration %d", i)
+			}
+		})
+	}
+}
+
+func TestLoadResourcesDeterministic(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected []string
+	}{
+		{
+			name:     "resource order is deterministic when multiple resources share a provider",
+			path:     "multi-provider-resources",
+			expected: []string{"aws_instance.second", "aws_s3_bucket.first", "tls_private_key.key"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			config := print.NewConfig()
+			module, err := loadModule(filepath.Join("testdata", tt.path))
+			assert.Nil(err)
+
+			for i := 0; i < 100; i++ {
+				rr := loadResources(module, config)
+
+				actual := make([]string, len(rr))
+				for j, r := range rr {
+					actual[j] = r.Spec()
+				}
+				assert.Equal(tt.expected, actual, "iteration %d", i)
+			}
+		})
+	}
+}
+
 func TestLoadComments(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/terraform/provider.go
+++ b/terraform/provider.go
@@ -45,6 +45,9 @@ func sortProvidersByName(x []*Provider) {
 func sortProvidersByPosition(x []*Provider) {
 	sort.Slice(x, func(i, j int) bool {
 		if x[i].Position.Filename == x[j].Position.Filename {
+			if x[i].Position.Line == x[j].Position.Line {
+				return x[i].FullName() < x[j].FullName()
+			}
 			return x[i].Position.Line < x[j].Position.Line
 		}
 		return x[i].Position.Filename < x[j].Position.Filename

--- a/terraform/testdata/multi-provider-resources/main.tf
+++ b/terraform/testdata/multi-provider-resources/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 4.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "first" {}
+
+resource "tls_private_key" "key" {}
+
+resource "aws_instance" "second" {}

--- a/terraform/testdata/providers-non-alpha-order/main.tf
+++ b/terraform/testdata/providers-non-alpha-order/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    tls = {
+      version = ">= 4.0"
+    }
+  }
+}
+
+resource "tls_private_key" "key" {}
+
+resource "aws_instance" "server" {}


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #898 

Providers and resources were returned in a non-deterministic order due to Go's randomized map iteration. This caused terraform-docs to produce different output on repeated runs, failing pre-commit hooks unnecessarily.
                                                                                                                                                                                
Three fixes in terraform/load.go and terraform/provider.go:                                                                                                                   
   
1. Collect from maps in sorted key order - both loadProviders and loadResources now sort map keys before building the result slice, so the input to all sort functions is always deterministic.                                     
2. Track the earliest position per provider - when a provider is referenced by multiple resources, its position is now always the earliest file+line across all its resources, not whichever resource happened to be iterated first.                                                                                                                        
3. Add a name tiebreaker to sortProvidersByPosition - prevents non-determinism when two providers share the same filename and line number.
                                                                                                                                                                                
### How has this code been tested                       
- Added testdata/multi-provider-resources together with new unit tests (TestLoadProvidersDeterministic, TestLoadResourcesDeterministic).


I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.



<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/JtEzg
