### PR TITLE
fix: config load with absolute path

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -146,6 +146,9 @@ func (r *Runtime) RunEFunc(cmd *cobra.Command, args []string) error { //nolint:g
 // them with corresponding flags (if set).
 func (r *Runtime) readConfig(v *viper.Viper, file string, submoduleDir string) error {
 	if r.isFlagChanged("config") {
+		if absFile, err := filepath.Abs(file); err == nil {
+			file = absFile
+		}
 		v.SetConfigFile(file)
 	} else {
 		v.SetConfigName(".terraform-docs")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -11,10 +11,62 @@ the root directory of this source tree.
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/terraform-docs/terraform-docs/print"
 )
+
+func TestReadConfigAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, ".terraform-docs.yml")
+
+	err := os.WriteFile(configFile, []byte("formatter: markdown table\n"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		file    string
+		wantErr bool
+	}{
+		"AbsolutePath": {
+			file:    configFile,
+			wantErr: false,
+		},
+		"NonExistentAbsolutePath": {
+			file:    filepath.Join(dir, "nonexistent.yml"),
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			runtime := &Runtime{
+				formatter: "markdown",
+				config:    print.DefaultConfig(),
+				isFlagChanged: func(flag string) bool {
+					return flag == "config"
+				},
+			}
+
+			v := viper.New()
+			err := runtime.readConfig(v, tt.file, "")
+
+			if tt.wantErr {
+				assert.NotNil(err)
+			} else {
+				assert.Nil(err)
+			}
+		})
+	}
+}
 
 func TestVersionConstraint(t *testing.T) {
 	type tuple struct {

--- a/print/config.go
+++ b/print/config.go
@@ -14,7 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -483,7 +483,7 @@ func ReadConfig(rootDir string, filename string) (*Config, error) {
 	cfg := NewConfig()
 
 	v := viper.New()
-	v.SetConfigFile(path.Join(rootDir, filename))
+	v.SetConfigFile(filepath.Join(rootDir, filename))
 
 	if err := v.ReadInConfig(); err != nil {
 		var perr *os.PathError

--- a/print/config_test.go
+++ b/print/config_test.go
@@ -12,6 +12,8 @@ package print
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -604,6 +606,46 @@ func TestConfigValidate(t *testing.T) {
 			if tt.wantErr {
 				assert.NotNil(err)
 				assert.Equal(tt.errMsg, err.Error())
+			} else {
+				assert.Nil(err)
+			}
+		})
+	}
+}
+
+func TestReadConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, ".terraform-docs.yml"), []byte("formatter: markdown table\nsort:\n  enabled: true\n  by: name\n"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		rootDir  string
+		filename string
+		wantErr  bool
+	}{
+		"Found": {
+			rootDir:  dir,
+			filename: ".terraform-docs.yml",
+			wantErr:  false,
+		},
+		"NotFound": {
+			rootDir:  dir,
+			filename: "nonexistent.yml",
+			wantErr:  true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			_, err := ReadConfig(tt.rootDir, tt.filename)
+
+			if tt.wantErr {
+				assert.NotNil(err)
 			} else {
 				assert.Nil(err)
 			}


### PR DESCRIPTION
### Description of your changes

Fixes #863

When using `-c /absolute/path/file.yml` on Windows with Git Bash (MSYS2/MinGW64), terraform-docs failed with `config file ... not found` even though the file existed. Relative paths worked fine.

**Root cause:** The POSIX-style absolute path passed from Git Bash was not converted to an OS-native path before being used by viper's file open call.

**Changes made:**
- `internal/cli/run.go`: resolve the config file path to an absolute OS-native path via `filepath.Abs` before passing to viper, ensuring consistent path handling for both relative and absolute inputs
- `print/config.go`: replace `path.Join` (URL path package) with `filepath.Join` (OS filesystem package) in `ReadConfig` to ensure correct path separators on all platforms

Small detail: The fix covers the common case. Windows/MSYS2 users where `/tmp` does not map to the current drive root should use Windows-style paths (`C:/path/to/file.yml`) or relative paths.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

- Added `TestReadConfigAbsolutePath` in `internal/cli/run_test.go`: verifies that `readConfig` correctly loads a config file given an absolute path, and errors on a non-existent absolute path.
- Added `TestReadConfig` in `print/config_test.go`: verifies that `ReadConfig` finds a config file by rootDir + relative filename and errors on a non-existent filename.
- Full test suite passes (`go test ./...`).

[contribution process]: https://git.io/JtEzg
