### PR TITLE
feat: improve recursive submodule scanning to traverse nested directories and add exclude support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.Recursive.Enabled, "recursive", false, "update submodules recursively (default false)")
 	cmd.PersistentFlags().StringVar(&config.Recursive.Path, "recursive-path", "modules", "submodules path to recursively update")
 	cmd.PersistentFlags().BoolVar(&config.Recursive.IncludeMain, "recursive-include-main", true, "include the main module")
+	cmd.PersistentFlags().StringSliceVar(&config.Recursive.Exclude, "recursive-exclude", []string{}, "exclude directories from recursive update")
 
 	cmd.PersistentFlags().StringSliceVar(&config.Sections.Show, "show", []string{}, "show section ["+print.AllSections+"]")
 	cmd.PersistentFlags().StringSliceVar(&config.Sections.Hide, "hide", []string{}, "hide section ["+print.AllSections+"]")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	goversion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
@@ -265,36 +266,42 @@ func (r *Runtime) findSubmodules() ([]module, error) {
 		return nil, err
 	}
 
-	info, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, err
-	}
-
 	modules := []module{}
 
-	for _, file := range info {
-		if !file.IsDir() {
-			continue
+	err := filepath.WalkDir(dir, func(path string, file os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !file.IsDir() || path == dir {
+			return nil
+		}
+
+		if file.IsDir() && strings.HasPrefix(file.Name(), ".") {
+			return filepath.SkipDir
 		}
 
 		var cfg *print.Config
 
-		path := filepath.Join(dir, file.Name())
 		cfgfile := filepath.Join(path, r.config.File)
-
 		if _, err := os.Stat(cfgfile); !os.IsNotExist(err) {
 			v := viper.New()
 
 			if err = r.readConfig(v, cfgfile, path); err != nil {
-				return nil, err
+				return err
 			}
 
 			if cfg, err = r.mergeConfig(v); err != nil {
-				return nil, err
+				return err
 			}
 		}
 
 		modules = append(modules, module{rootDir: path, config: cfg})
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
 	return modules, nil

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
@@ -277,7 +278,7 @@ func (r *Runtime) findSubmodules() ([]module, error) {
 			return nil
 		}
 
-		if file.IsDir() && strings.HasPrefix(file.Name(), ".") {
+		if strings.HasPrefix(file.Name(), ".") || slices.Contains(r.config.Recursive.Exclude, file.Name()) {
 			return filepath.SkipDir
 		}
 

--- a/print/config.go
+++ b/print/config.go
@@ -73,9 +73,10 @@ func DefaultConfig() *Config {
 }
 
 type recursive struct {
-	Enabled     bool   `mapstructure:"enabled"`
-	Path        string `mapstructure:"path"`
-	IncludeMain bool   `mapstructure:"include-main"`
+	Enabled     bool     `mapstructure:"enabled"`
+	Path        string   `mapstructure:"path"`
+	IncludeMain bool     `mapstructure:"include-main"`
+	Exclude     []string `mapstructure:"exclude"`
 }
 
 func defaultRecursive() recursive {
@@ -83,6 +84,7 @@ func defaultRecursive() recursive {
 		Enabled:     false,
 		Path:        "modules",
 		IncludeMain: true,
+		Exclude:     []string{},
 	}
 }
 


### PR DESCRIPTION
### Description of your changes
Fixes #585 might also address #661

This PR fixes a lot of created issues but the most relevant is #585
An alternative fix is to allow specifying multiple paths, but it's harder to maintain I think.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

I tested this against our infrastructure code at [OWASP Nest](https://github.com/OWASP/Nest/).

Run with `exclude: tests`
<img width="1460" height="548" alt="image" src="https://github.com/user-attachments/assets/5d2b6c4b-eea5-40c0-bec8-65cbf435139c" />

Run without `exclude` (affects `tests/`):
<img width="1229" height="884" alt="image" src="https://github.com/user-attachments/assets/c7f8a6e7-b691-4eb2-9d8a-6d419dcf4425" />
