### PR TITLE
fix: ignore directories without `.tf` files for docs generation

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -323,6 +323,27 @@ func (r *Runtime) loadSubModule(path string) (*module, error) {
 	return &module{rootDir: path, config: cfg}, nil
 }
 
+// containsTerraformFiles reports whether a directory contains Terraform files.
+func containsTerraformFiles(path string) (bool, error) {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := file.Name()
+		if strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tf.json") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // loadModuleConfig attempts to load a module configuration from the given directory path.
 func (r *Runtime) loadModuleConfig(path string) (*print.Config, error) {
 	var cfg *print.Config
@@ -361,27 +382,6 @@ func checkConstraint(versionRange string, currentVersion string) error {
 	}
 
 	return nil
-}
-
-// containsTerraformFiles reports whether a directory contains Terraform files.
-func containsTerraformFiles(path string) (bool, error) {
-	files, err := os.ReadDir(path)
-	if err != nil {
-		return false, err
-	}
-
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		name := file.Name()
-		if strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tf.json") {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 // generateContent extracts print.Settings and terraform.Options from normalized

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -285,6 +285,15 @@ func (r *Runtime) findSubmodules() ([]module, error) {
 			return filepath.SkipDir
 		}
 
+		hasTerraformFiles, err := containsTerraformFiles(path)
+		if err != nil {
+			return err
+		}
+
+		if !hasTerraformFiles {
+			return nil
+		}
+
 		cfg, err := r.loadModuleConfig(path)
 		if err != nil {
 			return err
@@ -339,6 +348,27 @@ func checkConstraint(versionRange string, currentVersion string) error {
 	}
 
 	return nil
+}
+
+// containsTerraformFiles reports whether a directory contains Terraform files.
+func containsTerraformFiles(path string) (bool, error) {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := file.Name()
+		if strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tf.json") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // generateContent extracts print.Settings and terraform.Options from normalized

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -285,21 +285,15 @@ func (r *Runtime) findSubmodules() ([]module, error) {
 			return filepath.SkipDir
 		}
 
-		hasTerraformFiles, err := containsTerraformFiles(path)
+		module, err := r.loadSubModule(path)
 		if err != nil {
 			return err
 		}
 
-		if !hasTerraformFiles {
-			return nil
+		if module != nil {
+			modules = append(modules, *module)
 		}
 
-		cfg, err := r.loadModuleConfig(path)
-		if err != nil {
-			return err
-		}
-
-		modules = append(modules, module{rootDir: path, config: cfg})
 		return nil
 	})
 
@@ -308,6 +302,25 @@ func (r *Runtime) findSubmodules() ([]module, error) {
 	}
 
 	return modules, nil
+}
+
+// loadSubModule attempts to load a submodule from the given directory path.
+func (r *Runtime) loadSubModule(path string) (*module, error) {
+	hasTerraformFiles, err := containsTerraformFiles(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hasTerraformFiles {
+		return nil, nil
+	}
+
+	cfg, err := r.loadModuleConfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &module{rootDir: path, config: cfg}, nil
 }
 
 // loadModuleConfig attempts to load a module configuration from the given directory path.


### PR DESCRIPTION
Fixes #929 

My previous PR #924 introduced a bug, I want to fix it.

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested
Tested this against a local project; A friend also tested this independently.

[contribution process]: https://git.io/JtEzg
