### PR TITLE
fix(codespell): Fix a range of typos and ignore a couple others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ site/
 
 # contributors.list
 contributors.list
+
+# local notes
+.local/

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ when formatter is set to `markdown table`.
 Note that sections visibility (i.e. `sections.show` and `sections.hide`) takes
 precedence over the `content`.
 
-Additionally there's also one extra special variable avaialble to the `content`:
+Additionally there's also one extra special variable available to the `content`:
 
 - `{{ .Module }}`
 

--- a/cmd/asciidoc/asciidoc.go
+++ b/cmd/asciidoc/asciidoc.go
@@ -35,7 +35,7 @@ func NewCommand(runtime *cli.Runtime, config *print.Config) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.Settings.Anchor, "anchor", true, "create anchor links")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Default, "default", true, "show Default column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
-	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of AsciiDoc sections [1, 2, 3, 4, 5]")
+	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indentation level of AsciiDoc sections [1, 2, 3, 4, 5]")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Type, "type", true, "show Type column or section")

--- a/cmd/markdown/markdown.go
+++ b/cmd/markdown/markdown.go
@@ -38,7 +38,7 @@ func NewCommand(runtime *cli.Runtime, config *print.Config) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&config.Settings.Escape, "escape", true, "escape special characters")
 	cmd.PersistentFlags().BoolVar(&config.Settings.HTML, "html", true, "use HTML tags in generated output")
 	cmd.PersistentFlags().BoolVar(&config.Settings.HideEmpty, "hide-empty", false, "hide empty sections (default false)")
-	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indention level of Markdown sections [1, 2, 3, 4, 5]")
+	cmd.PersistentFlags().IntVar(&config.Settings.Indent, "indent", 2, "indentation level of Markdown sections [1, 2, 3, 4, 5]")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Required, "required", true, "show Required column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Sensitive, "sensitive", true, "show Sensitive column or section")
 	cmd.PersistentFlags().BoolVar(&config.Settings.Type, "type", true, "show Type column or section")

--- a/docs/reference/asciidoc-document.md
+++ b/docs/reference/asciidoc-document.md
@@ -32,7 +32,7 @@ terraform-docs asciidoc document [PATH] [flags]
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-empty                  hide empty sections (default false)
-      --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
+      --indent int                  indentation level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")

--- a/docs/reference/asciidoc-table.md
+++ b/docs/reference/asciidoc-table.md
@@ -32,7 +32,7 @@ terraform-docs asciidoc table [PATH] [flags]
       --header-from string          relative path of a file to read header from (default "main.tf")
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-empty                  hide empty sections (default false)
-      --indent int                  indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
+      --indent int                  indentation level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")

--- a/docs/reference/asciidoc.md
+++ b/docs/reference/asciidoc.md
@@ -23,7 +23,7 @@ terraform-docs asciidoc [PATH] [flags]
       --default      show Default column or section (default true)
   -h, --help         help for asciidoc
       --hide-empty   hide empty sections (default false)
-      --indent int   indention level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
+      --indent int   indentation level of AsciiDoc sections [1, 2, 3, 4, 5] (default 2)
       --required     show Required column or section (default true)
       --sensitive    show Sensitive column or section (default true)
       --type         show Type column or section (default true)

--- a/docs/reference/markdown-document.md
+++ b/docs/reference/markdown-document.md
@@ -35,7 +35,7 @@ terraform-docs markdown document [PATH] [flags]
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-empty                  hide empty sections (default false)
       --html                        use HTML tags in generated output (default true)
-      --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
+      --indent int                  indentation level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")

--- a/docs/reference/markdown-table.md
+++ b/docs/reference/markdown-table.md
@@ -35,7 +35,7 @@ terraform-docs markdown table [PATH] [flags]
       --hide strings                hide section [all, data-sources, footer, header, inputs, modules, outputs, providers, requirements, resources]
       --hide-empty                  hide empty sections (default false)
       --html                        use HTML tags in generated output (default true)
-      --indent int                  indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
+      --indent int                  indentation level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --lockfile                    read .terraform.lock.hcl if exist (default true)
       --output-check                check if content of output file is up to date (default false)
       --output-file string          file path to insert output into (default "")

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -26,7 +26,7 @@ terraform-docs markdown [PATH] [flags]
   -h, --help         help for markdown
       --hide-empty   hide empty sections (default false)
       --html         use HTML tags in generated output (default true)
-      --indent int   indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
+      --indent int   indentation level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --required     show Required column or section (default true)
       --sensitive    show Sensitive column or section (default true)
       --type         show Type column or section (default true)

--- a/format/generator.go
+++ b/format/generator.go
@@ -152,34 +152,34 @@ func newGenerator(config *print.Config, canRender bool, fns ...generateFunc) *ge
 	return g
 }
 
-// Content returns generted all the sections combined based on the underlying format.
+// Content returns generated all the sections combined based on the underlying format.
 func (g *generator) Content() string { return g.content }
 
-// Header returns generted header section based on the underlying format.
+// Header returns generated header section based on the underlying format.
 func (g *generator) Header() string { return g.header }
 
-// Footer returns generted footer section based on the underlying format.
+// Footer returns generated footer section based on the underlying format.
 func (g *generator) Footer() string { return g.footer }
 
-// Inputs returns generted inputs section based on the underlying format.
+// Inputs returns generated inputs section based on the underlying format.
 func (g *generator) Inputs() string { return g.inputs }
 
-// Modules returns generted modules section based on the underlying format.
+// Modules returns generated modules section based on the underlying format.
 func (g *generator) Modules() string { return g.modules }
 
-// Outputs returns generted outputs section based on the underlying format.
+// Outputs returns generated outputs section based on the underlying format.
 func (g *generator) Outputs() string { return g.outputs }
 
-// Providers returns generted providers section based on the underlying format.
+// Providers returns generated providers section based on the underlying format.
 func (g *generator) Providers() string { return g.providers }
 
-// Requirements returns generted resources section based on the underlying format.
+// Requirements returns generated resources section based on the underlying format.
 func (g *generator) Requirements() string { return g.requirements }
 
-// Resources returns generted requirements section based on the underlying format.
+// Resources returns generated requirements section based on the underlying format.
 func (g *generator) Resources() string { return g.resources }
 
-// Module returns generted requirements section based on the underlying format.
+// Module returns generated requirements section based on the underlying format.
 func (g *generator) Module() *terraform.Module { return g.module }
 
 // funcs adds GenerateFunc to the list of available functions, for further use

--- a/format/util.go
+++ b/format/util.go
@@ -49,7 +49,7 @@ func sanitize(markdown string) string {
 // PrintFencedCodeBlock prints codes in fences, it automatically detects if
 // the input 'code' contains '\n' it will use multi line fence, otherwise it
 // wraps the 'code' inside single-tick block.
-// If the fenced is multi-line it also appens an extra '\n` at the end and
+// If the fenced is multi-line it also appends an extra '\n` at the end and
 // returns true accordingly, otherwise returns false for non-carriage return.
 func PrintFencedCodeBlock(code string, language string) (string, bool) {
 	if strings.Contains(code, "\n") {
@@ -61,7 +61,7 @@ func PrintFencedCodeBlock(code string, language string) (string, bool) {
 // PrintFencedAsciidocCodeBlock prints codes in fences, it automatically detects if
 // the input 'code' contains '\n' it will use multi line fence, otherwise it
 // wraps the 'code' inside single-tick block.
-// If the fenced is multi-line it also appens an extra '\n` at the end and
+// If the fenced is multi-line it also appends an extra '\n` at the end and
 // returns true accordingly, otherwise returns false for non-carriage return.
 func PrintFencedAsciidocCodeBlock(code string, language string) (string, bool) {
 	if strings.Contains(code, "\n") {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -197,7 +197,7 @@ func (r *Runtime) unmarshalConfig(v *viper.Viper, config *print.Config) error {
 	}
 
 	// explicitly setting formatter to Config for non-root commands this
-	// will effectively override formattter properties from config file
+	// will effectively override formatter properties from config file
 	// if 1) config file exists and 2) formatter is set and 3) explicitly
 	// a subcommand was executed in the terminal
 	if r.formatter != "root" {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -212,7 +212,7 @@ func (e Empty) MarshalJSON() ([]byte, error) {
 	return []byte(`""`), nil
 }
 
-// Number represents a 'number' value which is marshaled to `null` when emty in JSON and YAML
+// Number represents a 'number' value which is marshaled to `null` when empty in JSON and YAML
 type Number float64
 
 // nolint

--- a/print/config.go
+++ b/print/config.go
@@ -256,7 +256,7 @@ func (o *output) validate() error {
 	}
 
 	// No extra validation is needed for mode 'replace',
-	// the followings only apply for every other modes.
+	// the following only applies for every other modes.
 	if o.Mode == OutputModeReplace {
 		return nil
 	}

--- a/print/doc.go
+++ b/print/doc.go
@@ -45,5 +45,5 @@ the root directory of this source tree.
 // • `{{ .Providers }}`
 // • `{{ .Requirements }}`
 // • `{{ .Resources }}`
-// • `{{ include "path/fo/file" }}`
+// • `{{ include "path/to/file" }}`
 package print

--- a/template/sanitizer.go
+++ b/template/sanitizer.go
@@ -55,7 +55,7 @@ func SanitizeSection(s string, escape bool, html bool) string {
 				lastbreak = "\n"
 			}
 
-			// Adjust indention and linebreak for indented codeblock
+			// Adjust indentation and linebreak for indented codeblock
 			// https://github.com/terraform-docs/terraform-docs/issues/521
 			lastindent := ""
 			lines := strings.Split(segment, "\n")
@@ -206,9 +206,9 @@ func ConvertMultiLineText(s string, isTable bool, isHeader bool, showHTML bool) 
 // ConvertOneLineCodeBlock converts a multi-line code block into a one-liner.
 // Line breaks are replaced with single space.
 func ConvertOneLineCodeBlock(s string) string {
-	splitted := strings.Split(s, "\n")
+	split := strings.Split(s, "\n")
 	result := []string{}
-	for _, segment := range splitted {
+	for _, segment := range split {
 		if len(strings.TrimSpace(segment)) == 0 {
 			continue
 		}

--- a/template/sanitizer_test.go
+++ b/template/sanitizer_test.go
@@ -147,6 +147,7 @@ func TestSanitizeDocument(t *testing.T) {
 		name     string
 		filename string
 		escape   bool
+		expected string
 	}{
 		{
 			name:     "sanitize document item empty",
@@ -162,6 +163,10 @@ func TestSanitizeDocument(t *testing.T) {
 			name:     "sanitize document item codeblock",
 			filename: "codeblock",
 			escape:   true,
+			expected: "This is a complicated one. We need a newline.  \n" +
+				"And an example in a code block. Available options  \n" +
+				"are: foo | bar | baz\n\n" +
+				"```\ndefault = [\n  \"foo\"\n]\n```",
 		},
 	}
 	for _, tt := range tests {
@@ -172,11 +177,13 @@ func TestSanitizeDocument(t *testing.T) {
 			assert.Nil(err)
 
 			actual := SanitizeDocument(string(bytes), tt.escape, false)
-
-			expected, err := os.ReadFile(filepath.Join("testdata", "document", tt.filename+".expected"))
-			assert.Nil(err)
-
-			assert.Equal(string(expected), actual)
+			expected := tt.expected
+			if expected == "" {
+				b, err := os.ReadFile(filepath.Join("testdata", "document", tt.filename+".expected"))
+				assert.Nil(err)
+				expected = string(b)
+			}
+			assert.Equal(expected, actual)
 		})
 	}
 }
@@ -378,21 +385,21 @@ func TestConvertMultiLineText(t *testing.T) {
 			filename: "indentations",
 			isTable:  false,
 			showHTML: true,
-			expected: "This is is a multiline test which works\n\nKey  \n  Foo1: blah  \n  Foo2: blah\n\nKey2  \nFoo1: bar1  \nFoo2: bar2",
+			expected: "This is a multiline test which works\n\nKey  \n  Foo1: blah  \n  Foo2: blah\n\nKey2  \nFoo1: bar1  \nFoo2: bar2",
 		},
 		{
 			name:     "convert multi-line indentations",
 			filename: "indentations",
 			isTable:  true,
 			showHTML: true,
-			expected: "This is is a multiline test which works<br/><br/>Key<br/>  Foo1: blah<br/>  Foo2: blah<br/><br/>Key2<br/>Foo1: bar1<br/>Foo2: bar2",
+			expected: "This is a multiline test which works<br/><br/>Key<br/>  Foo1: blah<br/>  Foo2: blah<br/><br/>Key2<br/>Foo1: bar1<br/>Foo2: bar2",
 		},
 		{
 			name:     "convert multi-line indentations",
 			filename: "indentations",
 			isTable:  true,
 			showHTML: false,
-			expected: "This is is a multiline test which works  Key   Foo1: blah   Foo2: blah  Key2 Foo1: bar1 Foo2: bar2",
+			expected: "This is a multiline test which works  Key   Foo1: blah   Foo2: blah  Key2 Foo1: bar1 Foo2: bar2",
 		},
 	}
 	for _, tt := range tests {

--- a/template/sanitizer_test.go
+++ b/template/sanitizer_test.go
@@ -378,21 +378,21 @@ func TestConvertMultiLineText(t *testing.T) {
 			filename: "indentations",
 			isTable:  false,
 			showHTML: true,
-			expected: "This is is a multline test which works\n\nKey  \n  Foo1: blah  \n  Foo2: blah\n\nKey2  \nFoo1: bar1  \nFoo2: bar2",
+			expected: "This is is a multiline test which works\n\nKey  \n  Foo1: blah  \n  Foo2: blah\n\nKey2  \nFoo1: bar1  \nFoo2: bar2",
 		},
 		{
 			name:     "convert multi-line indentations",
 			filename: "indentations",
 			isTable:  true,
 			showHTML: true,
-			expected: "This is is a multline test which works<br/><br/>Key<br/>  Foo1: blah<br/>  Foo2: blah<br/><br/>Key2<br/>Foo1: bar1<br/>Foo2: bar2",
+			expected: "This is is a multiline test which works<br/><br/>Key<br/>  Foo1: blah<br/>  Foo2: blah<br/><br/>Key2<br/>Foo1: bar1<br/>Foo2: bar2",
 		},
 		{
 			name:     "convert multi-line indentations",
 			filename: "indentations",
 			isTable:  true,
 			showHTML: false,
-			expected: "This is is a multline test which works  Key   Foo1: blah   Foo2: blah  Key2 Foo1: bar1 Foo2: bar2",
+			expected: "This is is a multiline test which works  Key   Foo1: blah   Foo2: blah  Key2 Foo1: bar1 Foo2: bar2",
 		},
 	}
 	for _, tt := range tests {

--- a/template/template.go
+++ b/template/template.go
@@ -237,11 +237,11 @@ func normalize(s string, trimSpace bool) string {
 	if !trimSpace {
 		return s
 	}
-	splitted := strings.Split(s, "\n")
-	for i, v := range splitted {
-		splitted[i] = strings.TrimSpace(v)
+	split := strings.Split(s, "\n")
+	for i, v := range split {
+		split[i] = strings.TrimSpace(v)
 	}
-	return strings.Join(splitted, "\n")
+	return strings.Join(split, "\n")
 }
 
 // GenerateIndentation generates indentation of Markdown and AsciiDoc headers

--- a/template/testdata/document/codeblock.expected
+++ b/template/testdata/document/codeblock.expected
@@ -1,5 +1,5 @@
-This is a complicated one. We need a newline.  
-And an example in a code block. Availeble options  
+This is a complicated one. We need a newline.
+And an example in a code block. Available options
 are: foo | bar | baz
 
 ```

--- a/template/testdata/document/codeblock.expected
+++ b/template/testdata/document/codeblock.expected
@@ -1,9 +1,0 @@
-This is a complicated one. We need a newline.
-And an example in a code block. Available options
-are: foo | bar | baz
-
-```
-default = [
-  "foo"
-]
-```

--- a/template/testdata/document/codeblock.golden
+++ b/template/testdata/document/codeblock.golden
@@ -1,5 +1,5 @@
-This is a complicated one. We need a newline.  
-And an example in a code block. Availeble options
+This is a complicated one. We need a newline.
+And an example in a code block. Available options
 are: foo | bar | baz
 
 ```

--- a/template/testdata/multiline/indentations.golden
+++ b/template/testdata/multiline/indentations.golden
@@ -1,4 +1,4 @@
-This is is a multline test which works
+This is a multiline test which works
 
 Key
   Foo1: blah

--- a/template/testdata/section/codeblock.expected
+++ b/template/testdata/section/codeblock.expected
@@ -1,5 +1,5 @@
-This is a complicated one. We need a newline.  
-And an example in a code block. Availeble options
+This is a complicated one. We need a newline.
+And an example in a code block. Available options
 are: foo | bar | baz
 
 ```

--- a/template/testdata/section/codeblock.golden
+++ b/template/testdata/section/codeblock.golden
@@ -1,5 +1,5 @@
-This is a complicated one. We need a newline.  
-And an example in a code block. Availeble options
+This is a complicated one. We need a newline.
+And an example in a code block. Available options
 are: foo | bar | baz
 
 ```

--- a/template/testdata/table/codeblock-html.markdown.expected
+++ b/template/testdata/table/codeblock-html.markdown.expected
@@ -1,1 +1,1 @@
-This is a complicated one. We need a newline.<br/>And an example in a code block. Availeble options<br/>are: foo \| bar \| baz<pre>default = [<br/>  "foo"<br/>]</pre>
+This is a complicated one. We need a newline.<br/>And an example in a code block. Available options<br/>are: foo \| bar \| baz<pre>default = [<br/>  "foo"<br/>]</pre>

--- a/template/testdata/table/codeblock-nohtml.markdown.expected
+++ b/template/testdata/table/codeblock-nohtml.markdown.expected
@@ -1,1 +1,1 @@
-This is a complicated one. We need a newline. And an example in a code block. Availeble options are: foo \| bar \| baz ```default = [ "foo" ]```
+This is a complicated one. We need a newline. And an example in a code block. Available options are: foo \| bar \| baz ```default = [ "foo" ]```

--- a/template/testdata/table/codeblock.asciidoc.expected
+++ b/template/testdata/table/codeblock.asciidoc.expected
@@ -1,5 +1,5 @@
-This is a complicated one. We need a newline.  
-And an example in a code block. Availeble options
+This is a complicated one. We need a newline.
+And an example in a code block. Available options
 are: foo \| bar \| baz
 
 [source]

--- a/template/testdata/table/codeblock.golden
+++ b/template/testdata/table/codeblock.golden
@@ -1,5 +1,5 @@
-This is a complicated one. We need a newline.  
-And an example in a code block. Availeble options
+This is a complicated one. We need a newline.
+And an example in a code block. Available options
 are: foo | bar | baz
 
 ```

--- a/terraform/load_test.go
+++ b/terraform/load_test.go
@@ -466,7 +466,7 @@ func TestLoadSections(t *testing.T) {
 func TestLoadInputs(t *testing.T) {
 	type expected struct {
 		inputs    int
-		requireds int
+		requireds int // codespell:ignore requireds
 		optionals int
 	}
 	tests := []struct {
@@ -479,7 +479,7 @@ func TestLoadInputs(t *testing.T) {
 			path: "full-example",
 			expected: expected{
 				inputs:    7,
-				requireds: 2,
+				requireds: 2, // codespell:ignore requireds
 				optionals: 5,
 			},
 		},
@@ -488,7 +488,7 @@ func TestLoadInputs(t *testing.T) {
 			path: "no-required-inputs",
 			expected: expected{
 				inputs:    6,
-				requireds: 0,
+				requireds: 0, // codespell:ignore requireds
 				optionals: 6,
 			},
 		},
@@ -497,7 +497,7 @@ func TestLoadInputs(t *testing.T) {
 			path: "no-optional-inputs",
 			expected: expected{
 				inputs:    6,
-				requireds: 6,
+				requireds: 6, // codespell:ignore requireds
 				optionals: 0,
 			},
 		},
@@ -506,7 +506,7 @@ func TestLoadInputs(t *testing.T) {
 			path: "no-inputs",
 			expected: expected{
 				inputs:    0,
-				requireds: 0,
+				requireds: 0, // codespell:ignore requireds
 				optionals: 0,
 			},
 		},
@@ -517,10 +517,10 @@ func TestLoadInputs(t *testing.T) {
 
 			config := print.NewConfig()
 			module, _ := loadModule(filepath.Join("testdata", tt.path))
-			inputs, requireds, optionals := loadInputs(module, config)
+			inputs, requireds, optionals := loadInputs(module, config) // codespell:ignore requireds
 
 			assert.Equal(tt.expected.inputs, len(inputs))
-			assert.Equal(tt.expected.requireds, len(requireds))
+			assert.Equal(tt.expected.requireds, len(requireds)) // codespell:ignore requireds
 			assert.Equal(tt.expected.optionals, len(optionals))
 		})
 	}


### PR DESCRIPTION
## Summary

Ran codespell and went through to correct any typos and added a couple ignores.

## 🐛 Bug Fixes
- Some formatters would auto remove whitespace from codeblock [`5757539`](https://github.com/RemoteRabbit/terraform-docs/commit/5757539)
- Add codespell ignore to lines with `requireds` [`81a7656`](https://github.com/RemoteRabbit/terraform-docs/commit/81a7656)
- Fix typos in template/ [`35df166`](https://github.com/RemoteRabbit/terraform-docs/commit/35df166)
- Fix typos in print/ [`dab33b0`](https://github.com/RemoteRabbit/terraform-docs/commit/dab33b0)
- Fix typos in internal/ [`03c9369`](https://github.com/RemoteRabbit/terraform-docs/commit/03c9369)
- Fix typos in format/ [`0e6cd93`](https://github.com/RemoteRabbit/terraform-docs/commit/0e6cd93)
- Fix typos in docs/reference, these got fixed when running the generate after the rest got fixed [`022e534`](https://github.com/RemoteRabbit/terraform-docs/commit/022e534)
- Fix typos in cmd/* [`4515138`](https://github.com/RemoteRabbit/terraform-docs/commit/4515138)
- Fix typo in readme, avaialble -> available [`8814c21`](https://github.com/RemoteRabbit/terraform-docs/commit/8814c21)

## 🏗️ Operations
- Add .local/ to gitignore, often used for local repo notes [`ea50b6a`](https://github.com/RemoteRabbit/terraform-docs/commit/ea50b6a)

## 📁 File Changes

### Root (+3/-0 lines)
- `.gitignore` (+3) 📝

### Cmd (+2/-2 lines)
- `cmd/asciidoc/asciidoc.go` (+1/-1) 📝
- `cmd/markdown/markdown.go` (+1/-1) 📝

### Format (+12/-12 lines)
- `format/generator.go` (+10/-10) 📝
- `format/util.go` (+2/-2) 📝

### Internal (+2/-2 lines)
- `internal/cli/run.go` (+1/-1) 📝
- `internal/types/types.go` (+1/-1) 📝

### Print (+2/-2 lines)
- `print/config.go` (+1/-1) 📝
- `print/doc.go` (+1/-1) 📝

### Template (+20/-29 lines)
- `template/sanitizer.go` (+3/-3) 📝
- `template/template.go` (+4/-4) 📝
- `template/testdata/document/codeblock.expected` (-9) 🗑️
- `template/testdata/document/codeblock.golden` (+2/-2) 📝
- `template/testdata/multiline/indentations.golden` (+1/-1) 📝
- `template/testdata/section/codeblock.expected` (+2/-2) 📝
- `template/testdata/section/codeblock.golden` (+2/-2) 📝
- `template/testdata/table/codeblock-html.markdown.expected` (+1/-1) 📝
- `template/testdata/table/codeblock-nohtml.markdown.expected` (+1/-1) 📝
- `template/testdata/table/codeblock.asciidoc.expected` (+2/-2) 📝
- `template/testdata/table/codeblock.golden` (+2/-2) 📝

### Tests (+22/-15 lines)
- `template/sanitizer_test.go` (+15/-8) 📝
- `terraform/load_test.go` (+7/-7) 📝

### Documentation (+7/-7 lines)
- `README.md` (+1/-1) 📝
- `docs/reference/asciidoc-document.md` (+1/-1) 📝
- `docs/reference/asciidoc-table.md` (+1/-1) 📝
- `docs/reference/asciidoc.md` (+1/-1) 📝
- `docs/reference/markdown-document.md` (+1/-1) 📝
- `docs/reference/markdown-table.md` (+1/-1) 📝
- `docs/reference/markdown.md` (+1/-1) 📝

---

##### If you like this template check out the plugin [here](https://github.com/RemoteRabbit/pr-description.nvim)!

**Changes:** 29 files, +70 insertions, -69 deletions
**Commits:** 10
**Branch:** `fix/codespell-typos`
**Base:** `origin/master`

I have:

- [X] Read and followed terraform-docs' [contribution process].
- [X] All tests pass when I run `make test`.

### How has this code been tested

`make test`

[contribution process]: https://git.io/JtEzg
