### PR TITLE
Migrate to goreleaser dockers_v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,24 +79,16 @@ changelog:
     - title: "Chores"
       order: 9999
 
-dockers:
+dockers_v2:
   - dockerfile: scripts/release/Dockerfile
-    image_templates:
-      - "quay.io/terraform-docs/terraform-docs:latest-amd64"
-      - "quay.io/terraform-docs/terraform-docs:{{ .RawVersion }}-amd64"
-    use: buildx
-    build_flag_templates:
-    - "--pull"
-    - "--platform=linux/amd64"
-  - dockerfile: scripts/release/Dockerfile
-    image_templates:
-      - "quay.io/terraform-docs/terraform-docs:latest-arm64"
-      - "quay.io/terraform-docs/terraform-docs:{{ .RawVersion }}-arm64"
-    use: buildx
-    build_flag_templates:
-    - "--pull"
-    - "--platform=linux/arm64"
-    goarch: arm64
+    images:
+      - "quay.io/terraform-docs/terraform-docs"
+    tags:
+      - "{{ .RawVersion }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
 
 brews:
   - repository:

--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -7,7 +7,7 @@
 # the root directory of this source tree.
 
 FROM docker.io/library/alpine:3.23.4
-
-COPY terraform-docs /usr/local/bin/terraform-docs
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/terraform-docs /usr/local/bin/
 
 ENTRYPOINT ["terraform-docs"]


### PR DESCRIPTION
### Description of your changes

Updates the goreleaser config to use [docker_v2](https://goreleaser.com/customization/package/dockers_v2/) which supports multi-arch manifests.

Fixes #887
Supersedes #892

<!-- Fixes # -->

I have:

- [X] Read and followed terraform-docs' [contribution process].
- [X] All tests pass when I run `make test`.

### How has this code been tested

1. Ran `goreleaser release --snapshot --clean --skip=publish --skip=sign`
2. Ran `docker run --rm -it quay.io/terraform-docs/terraform-docs:0.0.0-amd64 --version`
3. Saw the version string matches the current one
