### PR TITLE
Support Terraform 1.15 const variables in module source and version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/terraform-docs/terraform-config-inspect v0.0.0-20250408153412-5b88c7ed5b63
+	github.com/hashicorp/terraform-config-inspect v0.0.0-20260709150029-2fb54c236733
 	golang.org/x/exp v0.0.0-20251209150349-8475f28825e9
 	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.7.0

--- a/terraform/load.go
+++ b/terraform/load.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
 
-	"github.com/terraform-docs/terraform-config-inspect/tfconfig"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/terraform-docs/terraform-docs/internal/reader"
 	"github.com/terraform-docs/terraform-docs/internal/types"
 	"github.com/terraform-docs/terraform-docs/print"

--- a/terraform/load_test.go
+++ b/terraform/load_test.go
@@ -82,6 +82,21 @@ func TestLoadModule(t *testing.T) {
 	}
 }
 
+func TestLoadModuleWithConstModuleVersion(t *testing.T) {
+	module, err := loadModule(filepath.Join("testdata", "module-const-version"))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	call, ok := module.ModuleCalls["vpc"]
+	if !assert.True(t, ok) {
+		return
+	}
+
+	assert.Equal(t, "terraform-aws-modules/vpc/aws", call.Source)
+	assert.Equal(t, "var.version", call.Version)
+}
+
 func TestGetFileFormat(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/terraform/testdata/module-const-version/main.tf
+++ b/terraform/testdata/module-const-version/main.tf
@@ -1,0 +1,10 @@
+variable "version" {
+  type    = string
+  default = "6.6.1"
+  const   = true
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = var.version
+}


### PR DESCRIPTION
### Description of your changes

This pull request updates `terraform-docs` to support Terraform 1.15's new capability of using constant variables and locals in module `source` and `version` attributes.

Terraform 1.15 introduced support for expressions such as:

```hcl
variable "version" {
  type    = string
  const   = true
  default = "6.6.1"
}

module "vpc" {
  source  = "terraform-aws-modules/vpc/aws"
  version = var.version
}
```

Currently, `terraform-docs` fails while loading the module with errors similar to:

```
Variables not allowed: Variables may not be used here.
```

The underlying issue is that the bundled `terraform-config-inspect` dependency predates Terraform 1.15 and attempts to decode `source` and `version` as literal strings using an empty evaluation context.

This change updates `terraform-docs` to use the upstream parser implementation that tolerates these expressions by preserving the raw HCL expression instead of returning a fatal diagnostic. This matches Terraform 1.15's language behavior and allows documentation generation to continue without requiring users to hardcode module versions or sources.

Fixes #927

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

Testing included the following scenarios:

- Verified that modules using literal `source` and `version` values continue to behave as before.
- Added a regression test covering a Terraform 1.15 module that uses a `const` input variable for the module `version`.
- Verified that module loading no longer fails when `source` or `version` reference `const` variables or local values.
- Confirmed that module call metadata preserves the original expression (for example, `var.version`) rather than producing a fatal parser error, allowing `terraform-docs` to generate documentation successfully.

This change is intentionally limited to parser compatibility and does not attempt to evaluate Terraform expressions. It simply adopts the upstream `terraform-config-inspect` behavior introduced to support Terraform 1.15 while preserving existing functionality for earlier Terraform versions.