### PR TITLE
fix: show "No resources." instead of an empty table when the visible resource kind has no entries

### DIFF
--- a/format/templates/asciidoc_document_resources.tmpl
+++ b/format/templates/asciidoc_document_resources.tmpl
@@ -1,5 +1,6 @@
 {{- if or .Config.Sections.Resources .Config.Sections.DataSources -}}
-    {{- if not .Module.Resources -}}
+    {{- $resources := visibleResources .Module.Resources -}}
+    {{- if not $resources -}}
         {{- if not .Config.Settings.HideEmpty -}}
             {{- indent 0 "=" }} Resources
 
@@ -9,13 +10,9 @@
         {{- indent 0 "=" }} Resources
 
         The following resources are used by this module:
-        {{ range .Module.Resources }}
-            {{- $isResource := and $.Config.Sections.Resources ( eq "resource" (printf "%s" .GetMode)) }}
-            {{- $isDataResource := and $.Config.Sections.DataSources ( eq "data source" (printf "%s" .GetMode)) }}
-            {{- if or $isResource $isDataResource }}
-                {{- $fullspec := ternary .URL (printf "%s[%s]" .URL .Spec) .Spec }}
-                - {{ $fullspec }} {{ printf "(%s)" .GetMode -}}
-            {{- end }}
+        {{ range $resources }}
+            {{- $fullspec := ternary .URL (printf "%s[%s]" .URL .Spec) .Spec }}
+            - {{ $fullspec }} {{ printf "(%s)" .GetMode -}}
         {{- end }}
     {{ end }}
 {{ end -}}

--- a/format/templates/asciidoc_table_resources.tmpl
+++ b/format/templates/asciidoc_table_resources.tmpl
@@ -1,5 +1,6 @@
 {{- if or .Config.Sections.Resources .Config.Sections.DataSources -}}
-    {{- if not .Module.Resources -}}
+    {{- $resources := visibleResources .Module.Resources -}}
+    {{- if not $resources -}}
         {{- if not .Config.Settings.HideEmpty -}}
             {{- indent 0 "=" }} Resources
 
@@ -11,13 +12,9 @@
         [cols="a,a",options="header,autowidth"]
         |===
         |Name |Type
-        {{- range .Module.Resources }}
-            {{- $isResource := and $.Config.Sections.Resources ( eq "resource" (printf "%s" .GetMode)) }}
-            {{- $isDataResource := and $.Config.Sections.DataSources ( eq "data source" (printf "%s" .GetMode)) }}
-            {{- if or $isResource $isDataResource }}
-                {{- $fullspec := ternary .URL (printf "%s[%s]" .URL .Spec) .Spec }}
-                |{{ $fullspec }} |{{ .GetMode }}
-            {{- end }}
+        {{- range $resources }}
+            {{- $fullspec := ternary .URL (printf "%s[%s]" .URL .Spec) .Spec }}
+            |{{ $fullspec }} |{{ .GetMode }}
         {{- end }}
         |===
     {{ end }}

--- a/format/templates/markdown_document_resources.tmpl
+++ b/format/templates/markdown_document_resources.tmpl
@@ -1,5 +1,6 @@
 {{- if or .Config.Sections.Resources .Config.Sections.DataSources -}}
-    {{- if not .Module.Resources -}}
+    {{- $resources := visibleResources .Module.Resources -}}
+    {{- if not $resources -}}
         {{- if not .Config.Settings.HideEmpty -}}
             {{- indent 0 "#" }} Resources{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
@@ -9,13 +10,9 @@
         {{- indent 0 "#" }} Resources{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
         The following resources are used by this module:
-        {{ range .Module.Resources }}
-            {{- $isResource := and $.Config.Sections.Resources ( eq "resource" (printf "%s" .GetMode)) }}
-            {{- $isDataResource := and $.Config.Sections.DataSources ( eq "data source" (printf "%s" .GetMode)) }}
-            {{- if or $isResource $isDataResource }}
-                {{- $fullspec := ternary .URL (printf "[%s](%s)" .Spec .URL) .Spec }}
-                - {{ $fullspec }} {{ printf "(%s)" .GetMode -}}
-            {{- end }}
+        {{ range $resources }}
+            {{- $fullspec := ternary .URL (printf "[%s](%s)" .Spec .URL) .Spec }}
+            - {{ $fullspec }} {{ printf "(%s)" .GetMode -}}
         {{- end }}
     {{ end }}
 {{ end -}}

--- a/format/templates/markdown_table_resources.tmpl
+++ b/format/templates/markdown_table_resources.tmpl
@@ -1,5 +1,6 @@
 {{- if or .Config.Sections.Resources .Config.Sections.DataSources -}}
-    {{- if not .Module.Resources -}}
+    {{- $resources := visibleResources .Module.Resources -}}
+    {{- if not $resources -}}
         {{- if not .Config.Settings.HideEmpty -}}
             {{- indent 0 "#" }} Resources{{ if .Config.Settings.AtxClosed }} {{ indent 0 "#" }}{{ end }}
 
@@ -10,13 +11,9 @@
 
         | Name | Type |
         | ---- | ---- |
-        {{- range .Module.Resources }}
-            {{- $isResource := and $.Config.Sections.Resources ( eq "resource" (printf "%s" .GetMode)) }}
-            {{- $isDataResource := and $.Config.Sections.DataSources ( eq "data source" (printf "%s" .GetMode)) }}
-            {{- if or $isResource $isDataResource }}
-                {{- $fullspec := ternary .URL (printf "[%s](%s)" .Spec .URL) .Spec }}
-                | {{ $fullspec }} | {{ .GetMode }} |
-            {{- end }}
+        {{- range $resources }}
+            {{- $fullspec := ternary .URL (printf "[%s](%s)" .Spec .URL) .Spec }}
+            | {{ $fullspec }} | {{ .GetMode }} |
         {{- end }}
     {{ end }}
 {{ end -}}

--- a/template/template.go
+++ b/template/template.go
@@ -165,6 +165,9 @@ func builtinFuncs(config *print.Config) gotemplate.FuncMap { // nolint:gocyclo
 		"tostring": func(s types.String) string {
 			return string(s)
 		},
+		"visibleResources": func(resources []*terraform.Resource) []*terraform.Resource {
+			return VisibleResources(resources, config)
+		},
 
 		// trim
 		"trim": func(cut string, s string) string {
@@ -242,6 +245,30 @@ func normalize(s string, trimSpace bool) string {
 		splitted[i] = strings.TrimSpace(v)
 	}
 	return strings.Join(splitted, "\n")
+}
+
+// VisibleResources filters a module's resources down to the ones that should
+// actually be shown, honoring the independent Sections.Resources (managed
+// resources) and Sections.DataSources (data sources) visibility flags.
+// Templates must use this - instead of ranging over .Module.Resources
+// directly and filtering per-entry - so that "is there anything to show"
+// (used to decide between the section header/table and the "No resources."
+// placeholder) is computed against the same filtered set that's actually
+// rendered. Previously a module containing only resources of the
+// currently-hidden kind (e.g. all managed resources, with
+// `sections.hide: [resources]`) would still print an empty "## Resources"
+// table instead of "No resources.", since the emptiness check ran against
+// the unfiltered list.
+func VisibleResources(resources []*terraform.Resource, config *print.Config) []*terraform.Resource {
+	visible := make([]*terraform.Resource, 0, len(resources))
+	for _, r := range resources {
+		isResource := config.Sections.Resources && r.GetMode() == "resource"
+		isDataResource := config.Sections.DataSources && r.GetMode() == "data source"
+		if isResource || isDataResource {
+			visible = append(visible, r)
+		}
+	}
+	return visible
 }
 
 // GenerateIndentation generates indentation of Markdown and AsciiDoc headers

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -556,3 +556,83 @@ func TestNormalize(t *testing.T) {
 		})
 	}
 }
+
+// TestVisibleResources is a regression test for the terraform-docs#603 bug: a
+// module containing only resources of the currently-hidden kind (e.g. all
+// managed resources with `sections.hide: [resources]`, and no data sources at
+// all) used to still print an empty "## Resources" table instead of "No
+// resources.", because emptiness was checked against the raw, unfiltered
+// resource list rather than the list actually rendered.
+func TestVisibleResources(t *testing.T) {
+	managed := &terraform.Resource{Type: "instance", Name: "example", ProviderName: "aws", Mode: "managed"}
+	dataSource := &terraform.Resource{Type: "caller_identity", Name: "current", ProviderName: "aws", Mode: "data"}
+
+	tests := []struct {
+		name           string
+		resources      []*terraform.Resource
+		showResources  bool
+		showDataSrc    bool
+		expectedLength int
+	}{
+		{
+			name:           "both sections shown returns all resources",
+			resources:      []*terraform.Resource{managed, dataSource},
+			showResources:  true,
+			showDataSrc:    true,
+			expectedLength: 2,
+		},
+		{
+			name:           "only resources shown filters out data sources",
+			resources:      []*terraform.Resource{managed, dataSource},
+			showResources:  true,
+			showDataSrc:    false,
+			expectedLength: 1,
+		},
+		{
+			name:           "only data sources shown filters out managed resources",
+			resources:      []*terraform.Resource{managed, dataSource},
+			showResources:  false,
+			showDataSrc:    true,
+			expectedLength: 1,
+		},
+		{
+			name:           "neither section shown returns empty",
+			resources:      []*terraform.Resource{managed, dataSource},
+			showResources:  false,
+			showDataSrc:    false,
+			expectedLength: 0,
+		},
+		{
+			// The exact #603 scenario: data-sources is visible (not hidden),
+			// but the module has none - resources is hidden, and the module's
+			// only entry is a managed resource. The result must be empty so
+			// templates render "No resources." rather than an empty table.
+			name:           "module has only the hidden kind returns empty",
+			resources:      []*terraform.Resource{managed},
+			showResources:  false,
+			showDataSrc:    true,
+			expectedLength: 0,
+		},
+		{
+			name:           "empty input returns empty",
+			resources:      []*terraform.Resource{},
+			showResources:  true,
+			showDataSrc:    true,
+			expectedLength: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			config := &print.Config{}
+			config.Sections.Resources = tt.showResources
+			config.Sections.DataSources = tt.showDataSrc
+
+			actual := VisibleResources(tt.resources, config)
+
+			assert.Len(actual, tt.expectedLength)
+			assert.NotNil(actual, "should return an empty slice, not nil, so text/template's `not` treats it consistently")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`sections.hide` (or `--hide`) for `resources`/`data-sources` doesn't actually hide an empty "Resources" section: a module containing only resources of the currently-hidden kind (e.g. all managed resources, with `sections.hide: [resources]`) still prints an empty `## Resources` table with just column headers, instead of the `No resources.` placeholder every other empty section uses.

```console
$ terraform-docs markdown --hide providers --hide resources .
## Resources

| Name | Type |
| ---- | ---- |

## Inputs
...
```

This issue has had a few slightly different reports collapsed into it (#603); I could only reproduce this specific one on current `master` — see "Investigation" below for the others.

## Root cause

For markdown/asciidoc output, the resources templates decide between the `No resources.` placeholder and the actual table by checking `{{- if not .Module.Resources -}}` — but `.Module.Resources` at that point is the module's **raw, unfiltered** resource list. (For `json`/`toml`/`xml`/`yaml` output, `copySections` in `format/util.go` pre-filters the module before it reaches the formatter, via `filterResourcesByMode` — but the template-based formats never call `copySections` at all; `markdown_table.go` etc. pass the raw module straight into `withModule`.)

The table body then applies a **second**, per-entry filter inside the `range` loop, based on `Sections.Resources`/`Sections.DataSources`. So a module with e.g. one managed resource and `Sections.Resources = false` looks non-empty at the top-level check (the raw list has one entry) → renders the header + table skeleton, but every row gets filtered out inside the loop → zero rows.

## Fix

Added `template.VisibleResources(resources, config)`, which applies the managed/data-source filtering once (same logic as the removed per-entry `$isResource`/`$isDataResource` checks), exposed to templates as `visibleResources`. Updated all four resources templates (`markdown_table_resources.tmpl`, `markdown_document_resources.tmpl`, `asciidoc_table_resources.tmpl`, `asciidoc_document_resources.tmpl`) to filter once up front, check emptiness against that filtered result, then range over it directly with no further per-row filtering.

## Investigation

Issue #603 has three commenters describing slightly different symptoms. I reproduced and fixed the first (mission-lblaney's, matching the exact scenario above). I could not reproduce the original reporter's exact case (`hide: [resources, data-sources]` still showing a data-source row) on current `master` — that specific combination already correctly renders nothing today, so it looks like something else fixed it since v0.16.0 (the version in that report). augustovictor's comment ("hides items of type `data` while keeping `resource` types" with `--hide data-sources`) describes correct, expected behavior rather than a bug.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] Added `TestVisibleResources` in `template/template_test.go`: 6 cases covering both-shown, resources-only, data-sources-only, neither-shown, the exact #603 regression scenario (module has only the hidden kind), and empty input
- [x] `go test ./...` - all green (ran in a Linux container to sidestep CRLF noise from my Windows dev checkout affecting unrelated golden-file comparisons across the whole suite; confirmed those specific failures are pre-existing/environment-only and unrelated to this change)
- [x] Manually verified all three reported scenarios end-to-end with a built binary:
  - hiding both `resources`+`data-sources` on a module with both kinds → section omitted entirely (unchanged, already correct)
  - hiding only `resources` on a module with both kinds → data source row still shows correctly (unchanged, already correct)
  - hiding `resources` on a module with *only* a managed resource → now shows `No resources.` instead of an empty table (the fix)

Fixes #603